### PR TITLE
Add Restify instrumentation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ At the time of writing, zipkin-js instruments these libraries:
 
 - cujojs/rest (zipkin-instrumentation-cujojs-rest)
 - express (zipkin-instrumentation-express)
+- restify (zipkin-instrumentation-restify)
 - fetch (zipkin-instrumentation-fetch)
 - memcached (zipkin-instrumentation-memcached)
 

--- a/packages/zipkin-instrumentation-restify/README.md
+++ b/packages/zipkin-instrumentation-restify/README.md
@@ -1,0 +1,24 @@
+# zipkin-instrumentation-restify
+
+A Restify plugin that adds Zipkin tracing to the application.
+
+## Usage
+
+```javascript
+const restify = require('restify');
+const {Tracer, ExplicitContext, ConsoleRecorder} = require('zipkin');
+const zipkinMiddleware = require('zipkin-instrumentation-restify').restifyMiddleware;
+
+const ctxImpl = new ExplicitContext();
+const recorder = new ConsoleRecorder();
+
+const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+
+const app = restify.createServer();
+
+// Add the Zipkin middleware
+app.use(zipkinMiddleware({
+  tracer,
+  serviceName: 'service-a' // name of this application
+}));
+```

--- a/packages/zipkin-instrumentation-restify/index.js
+++ b/packages/zipkin-instrumentation-restify/index.js
@@ -1,0 +1,1 @@
+module.exports.restifyMiddleware = require('./src/restifyMiddleware');

--- a/packages/zipkin-instrumentation-restify/package.json
+++ b/packages/zipkin-instrumentation-restify/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zipkin-instrumentation-restify",
+  "version": "0.2.2",
+  "description": "Restify middleware for instrumentation with Zipkin.js",
+  "main": "index.js",
+  "scripts": {
+    "test": "node ../../node_modules/mocha/bin/mocha --require ../../test/helper.js"
+  },
+  "author": "OpenZipkin <openzipkin.alt@gmail.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "devDependencies": {
+    "node-fetch": "^1.5.1",
+    "restify": "^4.1.1",
+    "zipkin": "^0.2.2"
+  }
+}

--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -1,0 +1,96 @@
+const {
+  Annotation,
+  HttpHeaders: Header,
+  option: {Some, None},
+  TraceId
+} = require('zipkin');
+const url = require('url');
+
+function containsRequiredHeaders(req) {
+  return req.header(Header.TraceId) !== undefined &&
+    req.header(Header.SpanId) !== undefined;
+}
+
+function stringToBoolean(str) {
+  return str === '1';
+}
+
+function stringToIntOption(str) {
+  try {
+    return new Some(parseInt(str));
+  } catch (err) {
+    return None;
+  }
+}
+
+module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', port = 0}) {
+  return function zipkinRestifyMiddleware(req, res, next) {
+    tracer.scoped(() => {
+      function readHeader(header) {
+        const val = req.header(header);
+        if (val != null) {
+          return new Some(val);
+        } else {
+          return None;
+        }
+      }
+
+      if (containsRequiredHeaders(req)) {
+        const spanId = readHeader(Header.SpanId);
+        spanId.ifPresent(sid => {
+          const traceId = readHeader(Header.TraceId);
+          const parentSpanId = readHeader(Header.ParentSpanId);
+          const sampled = readHeader(Header.Sampled);
+          const flags = readHeader(Header.Flags).flatMap(stringToIntOption).getOrElse(0);
+          const id = new TraceId({
+            traceId,
+            parentId: parentSpanId,
+            spanId: sid,
+            sampled: sampled.map(stringToBoolean),
+            flags
+          });
+          tracer.setId(id);
+        });
+      } else {
+        tracer.setId(tracer.createRootId());
+        if (req.header(Header.Flags)) {
+          const currentId = tracer.id;
+          const idWithFlags = new TraceId({
+            traceId: currentId.traceId,
+            parentId: currentId.parentId,
+            spanId: currentId.spanId,
+            sampled: currentId.sampled,
+            flags: readHeader(Header.Flags)
+          });
+          tracer.setId(idWithFlags);
+        }
+      }
+
+      const id = tracer.id;
+
+      tracer.recordServiceName(serviceName);
+      tracer.recordRpc(req.method);
+      tracer.recordBinary('http.url', url.format({
+        protocol: req.isSecure() ? 'https' : 'http',
+        host: req.header('host'),
+        pathname: req.path()
+      }));
+      tracer.recordAnnotation(new Annotation.ServerRecv());
+      tracer.recordAnnotation(new Annotation.LocalAddr({port}));
+
+      if (id.flags !== 0 && id.flags != null) {
+        tracer.recordBinary(Header.Flags, id.flags.toString());
+      }
+
+      res.on('finish', () => {
+        tracer.scoped(() => {
+          tracer.setId(id);
+          tracer.recordBinary('http.status_code', res.statusCode.toString());
+          tracer.recordAnnotation(new Annotation.ServerSend());
+        });
+      });
+
+      next();
+    });
+  };
+};

--- a/packages/zipkin-instrumentation-restify/test/.eslintrc
+++ b/packages/zipkin-instrumentation-restify/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true
+  }
+}

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -1,0 +1,85 @@
+const sinon = require('sinon');
+const {Tracer, ExplicitContext} = require('zipkin');
+const fetch = require('node-fetch');
+const restify = require('restify');
+const middleware = require('../src/restifyMiddleware');
+
+describe('restify middleware - integration test', () => {
+  it('should receive trace info from the client', done => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({recorder, ctxImpl});
+
+    ctxImpl.scoped(() => {
+      const app = restify.createServer();
+      app.use(middleware({
+        tracer,
+        serviceName: 'service-a'
+      }));
+      app.post('/foo', (req, res, next) => {
+        // Use setTimeout to test that the trace context is propagated into the callback
+        const ctx = ctxImpl.getContext();
+        setTimeout(() => {
+          ctxImpl.letContext(ctx, () => {
+            tracer.recordBinary('message', 'hello from within app');
+            res.send(202, {status: 'OK'});
+          });
+        }, 10);
+        return next();
+      });
+      const server = app.listen(0, () => {
+        const port = server.address().port;
+        const url = `http://127.0.0.1:${port}/foo`;
+        fetch(url, {
+          method: 'post',
+          headers: {
+            'X-B3-TraceId': 'aaa',
+            'X-B3-SpanId': 'bbb',
+            'X-B3-Flags': '1'
+          }
+        }).then(res => res.json()).then(() => {
+          server.close();
+
+          const annotations = record.args.map(args => args[0]);
+
+          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
+          annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
+
+          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+
+          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+          expect(annotations[1].annotation.name).to.equal('POST');
+
+          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[2].annotation.key).to.equal('http.url');
+          expect(annotations[2].annotation.value).to.equal(url);
+
+          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+
+          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('X-B3-Flags');
+          expect(annotations[5].annotation.value).to.equal('1');
+
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('message');
+          expect(annotations[6].annotation.value).to.equal('hello from within app');
+
+          expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[7].annotation.key).to.equal('http.status_code');
+          expect(annotations[7].annotation.value).to.equal('202');
+
+          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+          done();
+        })
+        .catch(err => {
+          server.close();
+          done(err);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
I created a port of the express middleware that works with [Restify](http://restify.com/). There's just a few APIs that vary between Restify and Express, mainly around what methods are available on the request object. I updated the integration tests to match and they currently pass. The README contains example usage as well. 

Anyway, I'm open to any changes. I could also publish this myself but thought it might belong with the other instrumentations you have available. Let me know! Thanks!