### PR TITLE
Fix kafka logger example in README

### DIFF
--- a/packages/zipkin-transport-kafka/README.md
+++ b/packages/zipkin-transport-kafka/README.md
@@ -8,7 +8,7 @@ This is a module that sends Zipkin trace data from zipkin-js to Kafka.
 
 ```javascript
 const {Tracer, BatchRecorder} = require('zipkin');
-const KafkaLogger = require('zipkin-transport-kafka');
+const {KafkaLogger} = require('zipkin-transport-kafka');
 
 const kafkaRecorder = new BatchRecorder({
   logger: new KafkaLogger({


### PR DESCRIPTION
Adding destructuring braces to `KafkaLogger` import