### PR TITLE
Adding HTTP transport module

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.0.0-beta.9",
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -1,0 +1,22 @@
+# Zipkin-transport-http
+This is a module that sends Zipkin trace data to a configurable HTTP endpoint.
+
+## Usage:
+
+`npm install zipkin-transport-http --save`
+
+```javascript
+const {Tracer, BatchRecorder} = require('zipkin');
+const {HttpLogger} = require('zipkin-transport-http');
+
+const httpRecorder = new BatchRecorder({
+  logger: new HttpLogger({
+    endpoint: 'http://localhost:9411/api/v1/spans'
+  })
+});
+
+const tracer = new Tracer({
+  httpRecorder,
+  ctxImpl // this would typically be a CLSContext or ExplicitContext
+});
+```

--- a/packages/zipkin-transport-http/index.js
+++ b/packages/zipkin-transport-http/index.js
@@ -1,0 +1,1 @@
+module.exports.HttpLogger = require('./src/HttpLogger');

--- a/packages/zipkin-transport-http/package.json
+++ b/packages/zipkin-transport-http/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "zipkin-transport-http",
+  "version": "0.2.2",
+  "description": "Transports Zipkin trace data via HTTP",
+  "main": "index.js",
+  "scripts": {
+    "test": "node ../../node_modules/mocha/bin/mocha --require ../../test/helper.js"
+  },
+  "author": "Openzipkin <openzipkin.alt@gmail.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "dependencies": {
+    "node-fetch": "^1.5.3"
+  },
+  "devDependencies": {
+    "body-parser": "^1.15.2",
+    "express": "^4.13.4",
+    "zipkin": "^0.2.2"
+  }
+}

--- a/packages/zipkin-transport-http/test/.eslintrc
+++ b/packages/zipkin-transport-http/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true
+  }
+}

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -1,0 +1,39 @@
+const {Tracer, BatchRecorder, Annotation, ExplicitContext} = require('zipkin');
+const HttpLogger = require('../src/HttpLogger');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+describe('HTTP transport - integration test', () => {
+  it('should send trace data via HTTP', function(done) {
+    const app = express();
+    app.use(bodyParser.json());
+    app.post('/api/v1/spans', (req, res) => {
+      res.status(202).json({});
+      const traceData = req.body;
+      expect(traceData.length).to.equal(1);
+      expect(traceData[0].name).to.equal('GET');
+      expect(traceData[0].binaryAnnotations.length).to.equal(2);
+      expect(traceData[0].annotations.length).to.equal(2);
+      this.server.close(done);
+    });
+    this.server = app.listen(0, () => {
+      this.port = this.server.address().port;
+      const httpLogger = new HttpLogger({
+        endpoint: `http://localhost:${this.port}/api/v1/spans`
+      });
+
+      const ctxImpl = new ExplicitContext();
+      const recorder = new BatchRecorder({logger: httpLogger});
+      const tracer = new Tracer({recorder, ctxImpl});
+
+      ctxImpl.scoped(() => {
+        tracer.recordAnnotation(new Annotation.ServerRecv());
+        tracer.recordServiceName('my-service');
+        tracer.recordRpc('GET');
+        tracer.recordBinary('http.url', 'http://example.com');
+        tracer.recordBinary('http.response_code', '200');
+        tracer.recordAnnotation(new Annotation.ServerSend());
+      });
+    });
+  });
+});

--- a/packages/zipkin/src/internalRepresentations.js
+++ b/packages/zipkin/src/internalRepresentations.js
@@ -6,6 +6,10 @@ function Endpoint({host = 0, port = 0}) {
   this.host = host;
   this.port = port;
 }
+function formatIPv4(host) {
+  return host ?
+    `${host >> 24 & 255}.${(host >> 16) & 255}.${(host >> 8) & 255}.${host & 255}` : 0;
+}
 Endpoint.prototype.isUnknown = function isUnknown() {
   return this.host === 0 && this.port === 0;
 };
@@ -14,6 +18,12 @@ Endpoint.prototype.toThrift = function toThrift() {
     ipv4: this.host,
     port: this.port
   });
+};
+Endpoint.prototype.toJSON = function toJSON() {
+  return {
+    ipv4: formatIPv4(this.host),
+    port: this.port
+  };
 };
 
 function ZipkinAnnotation({timestamp, value, endpoint, duration}) {
@@ -36,6 +46,19 @@ ZipkinAnnotation.prototype.toThrift = function toThrift() {
   }
   return res;
 };
+ZipkinAnnotation.prototype.toJSON = function toJSON() {
+  const res = {
+    value: this.value,
+    timestamp: this.timestamp
+  };
+  if (this.endpoint) {
+    res.endpoint = this.endpoint.toJSON();
+  }
+  if (this.duration) {
+    res.duration = this.duration;
+  }
+  return res;
+};
 ZipkinAnnotation.prototype.toString = function toString() {
   return `Annotation(value="${this.value}")`;
 };
@@ -53,6 +76,16 @@ BinaryAnnotation.prototype.toThrift = function toThrift() {
   });
   if (this.endpoint) {
     res.host = this.endpoint.toThrift();
+  }
+  return res;
+};
+BinaryAnnotation.prototype.toJSON = function toJSON() {
+  const res = {
+    key: this.key,
+    value: this.value
+  };
+  if (this.endpoint) {
+    res.endpoint = this.endpoint.toJSON();
   }
   return res;
 };
@@ -99,6 +132,11 @@ MutableSpan.prototype.overrideEndpoint = function overrideEndpoint(ann) {
   ep.service_name = this.service.getOrElse('Unknown');
   ann.host = ep;
 };
+MutableSpan.prototype.overrideEndpointJSON = function overrideEndpointJSON(ann) {
+  if (!ann.endpoint) {
+    ann.endpoint = this.endpoint.toJSON();
+  }
+};
 MutableSpan.prototype.toThrift = function toThrift() {
   const span = new thriftTypes.Span();
 
@@ -124,6 +162,31 @@ MutableSpan.prototype.toThrift = function toThrift() {
   });
 
   return span;
+};
+MutableSpan.prototype.toJSON = function toJSON() {
+  const trace = this.traceId;
+  const spanJson = {
+    traceId: trace.traceId,
+    name: this.name.getOrElse('Unknown'),
+    id: trace.spanId,
+    timestamp: this.started
+  };
+  trace._parentId.ifPresent(id => {
+    spanJson.parentId = id;
+  });
+  spanJson.annotations = this.annotations.map(ann => {
+    const annotationJson = ann.toJSON();
+    this.overrideEndpointJSON(annotationJson);
+    annotationJson.endpoint.serviceName = this.service.getOrElse('Unknown');
+    return annotationJson;
+  });
+  spanJson.binaryAnnotations = this.binaryAnnotations.map(ann => {
+    const annotationJson = ann.toJSON();
+    this.overrideEndpointJSON(annotationJson);
+    annotationJson.endpoint.serviceName = this.service.getOrElse('Unknown');
+    return annotationJson;
+  });
+  return spanJson;
 };
 MutableSpan.prototype.toString = function toString() {
   const annotations = this.annotations.map(a => a.toString()).join(', ');

--- a/packages/zipkin/test/internalRepresentations.test.js
+++ b/packages/zipkin/test/internalRepresentations.test.js
@@ -1,0 +1,88 @@
+const TraceId = require('../src/tracer/TraceId');
+const {
+  MutableSpan,
+  Endpoint,
+  ZipkinAnnotation,
+  BinaryAnnotation
+} = require('../src/internalRepresentations');
+const {Some, None} = require('../src/option');
+
+describe('JSON Formatting', () => {
+  const ms = new MutableSpan(new TraceId({
+    traceId: new Some('a'),
+    parentId: new Some('b'),
+    spanId: 'c',
+    sampled: None
+  }));
+  ms.setName('GET');
+  ms.setServiceName('PortalService');
+
+  const here = new Endpoint({host: 171520595, port: 8080});
+
+  ms.setEndpoint(here);
+  ms.addBinaryAnnotation(new BinaryAnnotation({
+    key: 'warning',
+    value: 'The cake is a lie',
+    endpoint: here
+  }));
+  ms.addAnnotation(new ZipkinAnnotation({
+    timestamp: 1,
+    endpoint: here,
+    value: 'sr'
+  }));
+  ms.addAnnotation(new ZipkinAnnotation({
+    timestamp: 2,
+    endpoint: here,
+    value: 'ss'
+  }));
+  ms.started = 1468441525803803;
+
+  const expected = {
+    traceId: 'a',
+    name: 'GET',
+    id: 'c',
+    parentId: 'b',
+    timestamp: 1468441525803803,
+    annotations: [
+      {
+        endpoint: {
+          serviceName: 'PortalService',
+          ipv4: '10.57.50.83',
+          port: 8080
+        },
+        timestamp: 1,
+        value: 'sr'
+      },
+      {
+        endpoint: {
+          serviceName: 'PortalService',
+          ipv4: '10.57.50.83',
+          port: 8080,
+        },
+        timestamp: 2,
+        value: 'ss'
+      }
+    ],
+    binaryAnnotations: [
+      {
+        key: 'warning',
+        value: 'The cake is a lie',
+        endpoint: {
+          serviceName: 'PortalService',
+          ipv4: '10.57.50.83',
+          port: 8080
+        }
+      }
+    ]
+  };
+
+  it('should transform correctly from MutableSpan to JSON representation', () => {
+    const spanJson = ms.toJSON();
+    expect(spanJson.traceId).to.equal(expected.traceId);
+    expect(spanJson.name).to.equal(expected.name);
+    expect(spanJson.id).to.equal(expected.id);
+    expect(spanJson.parentId).to.equal(expected.parentId);
+    expect(spanJson.annotations).to.deep.equal(expected.annotations);
+    expect(spanJson.binaryAnnotations).to.deep.equal(expected.binaryAnnotations);
+  });
+});


### PR DESCRIPTION
Fixes #15. I modeled most of this after the scribe and kafka loggers. Basically, there is just an internal queue that gets checked every second for new spans. If there are spans, it batches them up in a single JSON post (an array) and sends them to a configurable HTTP endpoint.

Let me know if you'd like any changes made! I've tested this on a Restify-based service and I also added unit / integration tests.