### PR TITLE
unref the timer in BatchRecorder

### DIFF
--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -18,13 +18,14 @@ class BatchRecorder {
 
     // read through the partials spans regularly
     // and collect any timed-out ones
-    setInterval(() => {
+    const timer = setInterval(() => {
       this.partialSpans.forEach((span, id) => {
         if (this._timedOut(span)) {
           this._writeSpan(id);
         }
       });
     }, 1000);
+    timer.unref();
   }
 
   _writeSpan(id) {


### PR DESCRIPTION
I noticed my node process wasn't exiting when there was nothing else running, and discovered it was the timer in BatchRecorder that was still running. Anyway, made the same fix that @sveisvei suggested to BatchRecorder to solve the problem.