### PR TITLE
fix "Missing required argument recorder" error

### DIFF
--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -9,14 +9,14 @@ This is a module that sends Zipkin trace data to a configurable HTTP endpoint.
 const {Tracer, BatchRecorder} = require('zipkin');
 const {HttpLogger} = require('zipkin-transport-http');
 
-const httpRecorder = new BatchRecorder({
+const recorder = new BatchRecorder({
   logger: new HttpLogger({
     endpoint: 'http://localhost:9411/api/v1/spans'
   })
 });
 
 const tracer = new Tracer({
-  httpRecorder,
+  recorder,
   ctxImpl // this would typically be a CLSContext or ExplicitContext
 });
 ```


### PR DESCRIPTION
Rename httpRecorder to recorder because Tracer is specifically looking for a parameter named "recorder" or it throws an error like:

Error: Tracer: Missing required argument recorder.
    at requiredArg (/Users/Kevin/myservice1/node_modules/zipkin/src/tracer/index.js:11:9)
    at new Tracer (/Users/Kevin/myservice1/node_modules/zipkin/src/tracer/index.js:17:16)
    at Object.<anonymous> (/Users/Kevin/myservice1/app.js:17:16)