### PR TITLE
Removes obsolete Annotation.duration

### DIFF
--- a/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
+++ b/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
@@ -104,7 +104,6 @@ Annotation = module.exports.Annotation = function(args) {
   this.timestamp = null;
   this.value = null;
   this.host = null;
-  this.duration = null;
   if (args) {
     if (args.timestamp !== undefined && args.timestamp !== null) {
       this.timestamp = args.timestamp;
@@ -114,9 +113,6 @@ Annotation = module.exports.Annotation = function(args) {
     }
     if (args.host !== undefined && args.host !== null) {
       this.host = new ttypes.Endpoint(args.host);
-    }
-    if (args.duration !== undefined && args.duration !== null) {
-      this.duration = args.duration;
     }
   }
 };
@@ -156,13 +152,6 @@ Annotation.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 4:
-      if (ftype == Thrift.Type.I32) {
-        this.duration = input.readI32();
-      } else {
-        input.skip(ftype);
-      }
-      break;
       default:
         input.skip(ftype);
     }
@@ -187,11 +176,6 @@ Annotation.prototype.write = function(output) {
   if (this.host !== null && this.host !== undefined) {
     output.writeFieldBegin('host', Thrift.Type.STRUCT, 3);
     this.host.write(output);
-    output.writeFieldEnd();
-  }
-  if (this.duration !== null && this.duration !== undefined) {
-    output.writeFieldBegin('duration', Thrift.Type.I32, 4);
-    output.writeI32(this.duration);
     output.writeFieldEnd();
   }
   output.writeFieldStop();

--- a/packages/zipkin/src/internalRepresentations.js
+++ b/packages/zipkin/src/internalRepresentations.js
@@ -26,11 +26,10 @@ Endpoint.prototype.toJSON = function toJSON() {
   };
 };
 
-function ZipkinAnnotation({timestamp, value, endpoint, duration}) {
+function ZipkinAnnotation({timestamp, value, endpoint}) {
   this.timestamp = timestamp;
   this.value = value;
   this.endpoint = endpoint;
-  this.duration = duration;
 }
 
 ZipkinAnnotation.prototype.toThrift = function toThrift() {
@@ -41,9 +40,6 @@ ZipkinAnnotation.prototype.toThrift = function toThrift() {
   if (this.endpoint) {
     res.host = this.endpoint.toThrift();
   }
-  if (this.duration) {
-    res.duration = this.duration; // must be in micros
-  }
   return res;
 };
 ZipkinAnnotation.prototype.toJSON = function toJSON() {
@@ -53,9 +49,6 @@ ZipkinAnnotation.prototype.toJSON = function toJSON() {
   };
   if (this.endpoint) {
     res.endpoint = this.endpoint.toJSON();
-  }
-  if (this.duration) {
-    res.duration = this.duration;
   }
   return res;
 };

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -73,18 +73,17 @@ class Tracer {
     return this._ctxImpl.getContext() || this._defaultTraceId;
   }
 
-  recordAnnotation(annotation, duration) {
+  recordAnnotation(annotation) {
     this.recorder.record(new Record({
       traceId: this.id,
       timestamp: now(),
-      annotation,
-      duration: fromNullable(duration)
+      annotation
     }));
   }
 
-  recordMessage(message, duration) {
+  recordMessage(message) {
     this.recordAnnotation(
-      new Annotation.Message(message), duration
+      new Annotation.Message(message)
     );
   }
 

--- a/packages/zipkin/src/tracer/record.js
+++ b/packages/zipkin/src/tracer/record.js
@@ -1,9 +1,8 @@
 class Record {
-  constructor({traceId, timestamp, annotation, duration}) {
+  constructor({traceId, timestamp, annotation}) {
     this.traceId = traceId;
     this.timestamp = timestamp;
     this.annotation = annotation;
-    this.duration = duration;
   }
   toString() {
     return `Record(traceId=${this.traceId.toString()}, annotation=${this.annotation.toString()})`;

--- a/packages/zipkin/src/zipkinCore.thrift
+++ b/packages/zipkin/src/zipkinCore.thrift
@@ -22,7 +22,7 @@ struct Annotation {
   1: i64 timestamp                 # microseconds from epoch
   2: string value                  # what happened at the timestamp?
   3: optional Endpoint host        # host this happened on
-  4: optional i32 duration         # how long did the operation take? microseconds
+  // don't reuse 4: optional i32 OBSOLETE_duration         // how long did the operation take? microseconds
 }
 
 enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }


### PR DESCRIPTION
Annotation.duration is an obsolete field and was removed last year from
the thrift.