### PR TITLE
Fixes bug where millis were used as micros

### DIFF
--- a/packages/zipkin/src/time.js
+++ b/packages/zipkin/src/time.js
@@ -1,4 +1,4 @@
+// Returns the current time in epoch microseconds
 module.exports.now = function now() {
-  const d = new Date();
-  return d.getTime() * 1000 + d.getMilliseconds();
+  return new Date().getTime() * 1000;
 };


### PR DESCRIPTION
Before, the microsecond portion of the timestamp was filled with the
milliseconds value. This is mostly harmless, but incorrect. It is
better to truncate to millis until we record microsecond granularity.

See #3