### PR TITLE
Fix javascript example in zipkin-transport-kafka package

### DIFF
--- a/packages/zipkin-transport-kafka/README.md
+++ b/packages/zipkin-transport-kafka/README.md
@@ -19,7 +19,7 @@ const kafkaRecorder = new BatchRecorder({
 });
 
 const tracer = new Tracer({
-  kafkaRecorder,
+  recorder: kafkaRecorder,
   ctxImpl // this would typically be a CLSContext or ExplicitContext
 });
 ```


### PR DESCRIPTION
There are two required keys when creating a Tracer, `ctxImpl` and `recorder`, the latter key was missing in the example. 

cc @rodrwan