### PR TITLE
Fixed the reported path with querystring.

### DIFF
--- a/packages/zipkin-instrumentation-express/src/expressMiddleware.js
+++ b/packages/zipkin-instrumentation-express/src/expressMiddleware.js
@@ -23,6 +23,16 @@ function stringToIntOption(str) {
   }
 }
 
+function formatRequestUrl(req) {
+  const parsed = url.parse(req.originalUrl);
+  return url.format({
+    protocol: req.protocol,
+    host: req.get('host'),
+    pathname: parsed.pathname,
+    search: parsed.search
+  });
+}
+
 module.exports = function expressMiddleware({tracer, serviceName = 'unknown', port = 0}) {
   return function zipkinExpressMiddleware(req, res, next) {
     tracer.scoped(() => {
@@ -70,11 +80,7 @@ module.exports = function expressMiddleware({tracer, serviceName = 'unknown', po
 
       tracer.recordServiceName(serviceName);
       tracer.recordRpc(req.method);
-      tracer.recordBinary('http.url', url.format({
-        protocol: req.protocol,
-        host: req.get('host'),
-        pathname: req.originalUrl
-      }));
+      tracer.recordBinary('http.url', formatRequestUrl(req));
       tracer.recordAnnotation(new Annotation.ServerRecv());
       tracer.recordAnnotation(new Annotation.LocalAddr({port}));
 


### PR DESCRIPTION
This fixes the reporting of the path when the path includes a query string. Previously, a URL like `http://localhost:8180/api/bonjour?_=1473407259102` would be reported on `http.url` as `http://localhost:8180/api/bonjour%3F_=1473407259102`. With this change, the `http.url` is now reported as `http://localhost:8180/api/bonjour?_=1473407259102`.

Before: https://snag.gy/xr4Zow.jpg
After: https://snag.gy/z4VB5O.jpg
References: https://nodejs.org/api/url.html#url_url_format_urlobject
