### PR TITLE
Tolerate reads of 128 bit X-B3-TraceId

### DIFF
--- a/packages/zipkin-instrumentation-express/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/integrationTest.js
@@ -82,6 +82,7 @@ describe('express middleware - integration test', () => {
       });
     });
   });
+
   it('should properly report the URL with a query string', done => {
     const record = sinon.spy();
     const recorder = {record};
@@ -117,6 +118,57 @@ describe('express middleware - integration test', () => {
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
           expect(annotations[2].annotation.key).to.equal('http.url');
           expect(annotations[2].annotation.value).to.equal(url);
+          done();
+        })
+        .catch(err => {
+          server.close();
+          done(err);
+        });
+      });
+    });
+  });
+
+  // Once zipkin supports it, we can add a flag to propagate and report 128-bit
+  // trace identifiers. Until then, tolerantly read them.
+  // https://github.com/openzipkin/zipkin/issues/1298
+  it('should drop high bits of a 128bit X-B3-TraceId', done => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({recorder, ctxImpl});
+
+    ctxImpl.scoped(() => {
+      const app = express();
+      app.use(middleware({
+        tracer,
+        serviceName: 'service-a'
+      }));
+      app.post('/foo', (req, res) => {
+        // Use setTimeout to test that the trace context is propagated into the callback
+        const ctx = ctxImpl.getContext();
+        setTimeout(() => {
+          ctxImpl.letContext(ctx, () => {
+            tracer.recordBinary('message', 'hello from within app');
+            res.status(202).json({status: 'OK'});
+          });
+        }, 10);
+      });
+      const server = app.listen(0, () => {
+        const port = server.address().port;
+        const url = `http://127.0.0.1:${port}/foo`;
+        fetch(url, {
+          method: 'post',
+          headers: {
+            'X-B3-TraceId': '863ac35c9f6413ad48485a3953bb6124',
+            'X-B3-SpanId': '48485a3953bb6124',
+            'X-B3-Flags': '1'
+          }
+        }).then(res => res.json()).then(() => {
+          server.close();
+
+          const annotations = record.args.map(args => args[0]);
+
+          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('48485a3953bb6124'));
           done();
         })
         .catch(err => {

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -1,12 +1,21 @@
 const {Some, None, verifyIsOptional} = require('../option');
 
+// truncates a 128 bit hex-encoded trace ID to its lower 64 bits
+function coerceTo64Bit(str) {
+  if (str.length <= 16) {
+    return str;
+  } else {
+    return str.substr(str.length - 16);
+  }
+}
+
 class TraceId {
   constructor(params) {
     const {traceId = None, parentId = None, spanId, sampled = None, flags = 0} = params;
     verifyIsOptional(traceId);
     verifyIsOptional(parentId);
     verifyIsOptional(sampled);
-    this._traceId = traceId;
+    this._traceId = traceId.map(coerceTo64Bit);
     this._parentId = parentId;
     this._spanId = spanId;
     this._sampled = sampled;

--- a/packages/zipkin/test/TraceId.test.js
+++ b/packages/zipkin/test/TraceId.test.js
@@ -1,0 +1,20 @@
+const {Some} = require('../src/option');
+const TraceId = require('../src/tracer/TraceId');
+
+describe('TraceId', () => {
+  it('should leave 64bit trace ids alone', () => {
+    const traceId = new TraceId({
+      traceId: new Some('48485a3953bb6124'),
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+  });
+
+  it('should drop high bits of a 128bit trace id', () => {
+    const traceId = new TraceId({
+      traceId: new Some('863ac35c9f6413ad48485a3953bb6124'),
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+  });
+});


### PR DESCRIPTION
The first step of transitioning to 128bit `X-B3-TraceId` is tolerantly reading 32 character long ids by throwing away the high bits (any characters left of 16 characters). This allows the tracing system to more flexibly introduce 128bit trace id support in the future.

Ex. when `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124` is received, parse the lower 64 bits (right most 16 characters ex48485a3953bb6124) as the trace id.

See https://github.com/openzipkin/b3-propagation/issues/6