### PR TITLE
upgrade kafka-node

### DIFF
--- a/packages/zipkin-transport-kafka/package.json
+++ b/packages/zipkin-transport-kafka/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "kafka-node": "^0.3.2"
+    "kafka-node": "^0.5.9"
   },
   "devDependencies": {
     "kafka-please": "^0.1.5",


### PR DESCRIPTION
closes #24.

There should be only fixes here, so a minor jump is fine.
https://github.com/SOHU-Co/kafka-node/blob/master/CHANGELOG.md