### PR TITLE
Adds remoteServiceName which maps to the ServerAddr binary annotation

### DIFF
--- a/packages/zipkin-instrumentation-cujojs-rest/README.md
+++ b/packages/zipkin-instrumentation-cujojs-rest/README.md
@@ -12,7 +12,7 @@ const {restInterceptor} = require('zipkin-instrumentation-cujojs-rest');
 const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
 
 const nameOfRemoteService = 'youtube';
-const client = rest.wrap(restInterceptor, {tracer, serviceName: nameOfRemoteService});
+const client = rest.wrap(restInterceptor, {tracer, remoteServiceName: nameOfRemoteService});
 
 // Your application code here
 client('http://www.youtube.com/').then(success => {

--- a/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
@@ -16,7 +16,7 @@ function getRequestMethod(req) {
   return method;
 }
 
-function request(req, {serviceName, tracer}) {
+function request(req, {tracer, serviceName = 'unknown', remoteServiceName}) {
   tracer.scoped(() => {
     tracer.setId(tracer.createChildId());
     const traceId = tracer.id;
@@ -37,6 +37,12 @@ function request(req, {serviceName, tracer}) {
     tracer.recordRpc(method.toUpperCase());
     tracer.recordBinary('http.url', req.path);
     tracer.recordAnnotation(new Annotation.ClientSend());
+    if (remoteServiceName) {
+      // TODO: can we get the host and port of the http connection?
+      tracer.recordAnnotation(new Annotation.ServerAddr({
+        serviceName: remoteServiceName
+      }));
+    }
   });
 
   return req;

--- a/packages/zipkin-instrumentation-fetch/README.md
+++ b/packages/zipkin-instrumentation-fetch/README.md
@@ -14,7 +14,7 @@ const wrapFetch = require('zipkin-instrumentation-fetch');
 const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
 
 const nameOfRemoteService = 'youtube';
-const zipkinFetch = wrapFetch(fetch, {tracer, serviceName: nameOfRemoteService});
+const zipkinFetch = wrapFetch(fetch, {tracer, remoteServiceName: nameOfRemoteService});
 
 // Your application code here
 zipkinFetch('http://www.youtube.com/').then(res => res.json()).then(data => ...);

--- a/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
+++ b/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
@@ -15,7 +15,7 @@ function getHeaders(traceId, opts) {
   return headers;
 }
 
-function wrapFetch(fetch, {serviceName, tracer}) {
+function wrapFetch(fetch, {tracer, serviceName = 'unknown', remoteServiceName}) {
   return function zipkinfetch(url, opts = {}) {
     return new Promise((resolve, reject) => {
       tracer.scoped(() => {
@@ -27,6 +27,12 @@ function wrapFetch(fetch, {serviceName, tracer}) {
         tracer.recordRpc(method.toUpperCase());
         tracer.recordBinary('http.url', url);
         tracer.recordAnnotation(new Annotation.ClientSend());
+        if (remoteServiceName) {
+          // TODO: can we get the host and port of the http connection?
+          tracer.recordAnnotation(new Annotation.ServerAddr({
+            serviceName: remoteServiceName
+          }));
+        }
 
         const headers = getHeaders(traceId, opts);
         const zipkinOpts = Object.assign({}, opts, {headers});

--- a/packages/zipkin-instrumentation-redis/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-redis/src/zipkinClient.js
@@ -1,6 +1,17 @@
 const {Annotation} = require('zipkin');
 const redisCommands = require('redis-commands');
-module.exports = function zipkinClient(tracer, redis, options, serviceName = 'redis') {
+module.exports = function zipkinClient(
+  tracer,
+  redis,
+  options,
+  serviceName = 'unknown',
+  remoteServiceName = 'redis'
+) {
+  const sa = {
+    serviceName: remoteServiceName,
+    host: options.host,
+    port: options.port
+  };
   function mkZipkinCallback(callback, id) {
     return function zipkinCallback(...args) {
       tracer.scoped(() => {
@@ -11,9 +22,10 @@ module.exports = function zipkinClient(tracer, redis, options, serviceName = 're
     };
   }
   function commonAnnotations(rpc) {
-    tracer.recordAnnotation(new Annotation.ClientSend());
-    tracer.recordServiceName(serviceName);
     tracer.recordRpc(rpc);
+    tracer.recordAnnotation(new Annotation.ServiceName(serviceName));
+    tracer.recordAnnotation(new Annotation.ServerAddr(sa));
+    tracer.recordAnnotation(new Annotation.ClientSend());
   }
 
 

--- a/packages/zipkin/src/annotation.js
+++ b/packages/zipkin/src/annotation.js
@@ -39,12 +39,13 @@ ClientAddr.prototype.toString = function() {
   return `ClientAddr(host="${this.host}", port=${this.port})`;
 };
 
-function ServerAddr({host, port}) {
-  this.host = host;
-  this.port = port;
+function ServerAddr({serviceName, host, port}) {
+  this.serviceName = serviceName;
+  this.host = host || undefined;
+  this.port = port || 0;
 }
 ServerAddr.prototype.toString = function() {
-  return `ServerAddr(host="${this.host}", port=${this.port})`;
+  return `ServerAddr(serviceName="${this.serviceName}", host="${this.host}", port=${this.port})`;
 };
 
 function LocalAddr({host, port}) {

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -107,6 +107,13 @@ class BatchRecorder {
             port: rec.annotation.port
           }));
           break;
+        case 'ServerAddr':
+          span.setServerAddr(new Endpoint({
+            serviceName: rec.annotation.serviceName,
+            host: rec.annotation.host ? rec.annotation.host.toInt() : undefined,
+            port: rec.annotation.port
+          }));
+          break;
         default:
           break;
       }

--- a/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
+++ b/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
@@ -478,3 +478,4 @@ ttypes.CLIENT_SEND = 'cs';
 ttypes.CLIENT_RECV = 'cr';
 ttypes.SERVER_SEND = 'ss';
 ttypes.SERVER_RECV = 'sr';
+ttypes.SERVER_ADDR = 'sa';

--- a/packages/zipkin/src/zipkinCore.thrift
+++ b/packages/zipkin/src/zipkinCore.thrift
@@ -9,6 +9,7 @@ const string CLIENT_SEND = "cs"
 const string CLIENT_RECV = "cr"
 const string SERVER_SEND = "ss"
 const string SERVER_RECV = "sr"
+const string SERVER_ADDR = "sa"
 
 # this represents a host and port in a network
 struct Endpoint {
@@ -43,4 +44,3 @@ struct Span {
   8: list<BinaryAnnotation> binary_annotations # any binary annotations
   9: optional bool debug = 0       # if true, we DEMAND that this span passes all samplers
 }
-

--- a/packages/zipkin/test/internalRepresentations.test.js
+++ b/packages/zipkin/test/internalRepresentations.test.js
@@ -147,4 +147,32 @@ describe('JSON Formatting', () => {
 
     clock.uninstall();
   });
+
+  it('should set server address on client span', () => {
+    const clientSpan = new MutableSpan(new TraceId({
+      traceId: new Some('a'),
+      parentId: new Some('b'),
+      spanId: 'c',
+      sampled: None
+    }));
+    clientSpan.setName('GET');
+    clientSpan.setServerAddr(new Endpoint({
+      serviceName: 'there',
+      host: 171520596,
+      port: 80
+    }));
+
+    const spanJson = clientSpan.toJSON();
+    expect(spanJson.binaryAnnotations).to.deep.equal([
+      {
+        key: 'sa',
+        value: true,
+        endpoint: {
+          serviceName: 'there',
+          ipv4: '10.57.50.84',
+          port: 80
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
The ServerAddr("sa") annotation is used to indicate the server. This is
used for uninstrumented clients, such as redis. When used properly, the
Zipkin dependencies graph will show those who call into such services.

This adds an option `remoteServiceName` which hints the name of the
peer. Where possible, other endpoint information such as host and port
are added.

Fixes #52