### PR TITLE
Upgrade to kafka-node@1.0.0

### DIFF
--- a/packages/zipkin-transport-kafka/package.json
+++ b/packages/zipkin-transport-kafka/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "kafka-node": "^0.5.9"
+    "kafka-node": "^1.0.0"
   },
   "devDependencies": {
     "kafka-please": "^0.1.5",


### PR DESCRIPTION
Breaking change is dropped support for node < 4, which is no problem here.

https://github.com/SOHU-Co/kafka-node/blob/master/CHANGELOG.md

/cc @sveisvei @eirslett 