### PR TITLE
Propagates, reports and optionally generates 128-bit trace IDs

### DIFF
--- a/packages/zipkin-instrumentation-express/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/integrationTest.js
@@ -128,10 +128,7 @@ describe('express middleware - integration test', () => {
     });
   });
 
-  // Once zipkin supports it, we can add a flag to propagate and report 128-bit
-  // trace identifiers. Until then, tolerantly read them.
-  // https://github.com/openzipkin/zipkin/issues/1298
-  it('should drop high bits of a 128bit X-B3-TraceId', done => {
+  it('should accept a 128bit X-B3-TraceId', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
@@ -154,12 +151,13 @@ describe('express middleware - integration test', () => {
         }, 10);
       });
       const server = app.listen(0, () => {
+        const traceId = '863ac35c9f6413ad48485a3953bb6124';
         const port = server.address().port;
         const url = `http://127.0.0.1:${port}/foo`;
         fetch(url, {
           method: 'post',
           headers: {
-            'X-B3-TraceId': '863ac35c9f6413ad48485a3953bb6124',
+            'X-B3-TraceId': traceId,
             'X-B3-SpanId': '48485a3953bb6124',
             'X-B3-Flags': '1'
           }
@@ -168,7 +166,7 @@ describe('express middleware - integration test', () => {
 
           const annotations = record.args.map(args => args[0]);
 
-          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('48485a3953bb6124'));
+          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal(traceId));
           done();
         })
         .catch(err => {

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -106,10 +106,7 @@ describe('hapi middleware - integration test', () => {
     });
   });
 
-  // Once zipkin supports it, we can add a flag to propagate and report 128-bit
-  // trace identifiers. Until then, tolerantly read them.
-  // https://github.com/openzipkin/zipkin/issues/1298
-  it('should drop high bits of a 128bit X-B3-TraceId', done => {
+  it('should accept a 128bit X-B3-TraceId', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
@@ -132,17 +129,18 @@ describe('hapi middleware - integration test', () => {
         options: {tracer, serviceName: 'service-a'}
       });
 
+      const traceId = '863ac35c9f6413ad48485a3953bb6124';
       const method = 'POST';
       const url = '/foo';
       const headers = {
-        'X-B3-TraceId': '863ac35c9f6413ad48485a3953bb6124',
+        'X-B3-TraceId': traceId,
         'X-B3-SpanId': '48485a3953bb6124',
         'X-B3-Flags': '1'
       };
       server.inject({method, url, headers}, () => {
         const annotations = record.args.map(args => args[0]);
 
-        annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('48485a3953bb6124'));
+        annotations.forEach(ann => expect(ann.traceId.traceId).to.equal(traceId));
 
         done();
       });

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -83,10 +83,7 @@ describe('restify middleware - integration test', () => {
     });
   });
 
-  // Once zipkin supports it, we can add a flag to propagate and report 128-bit
-  // trace identifiers. Until then, tolerantly read them.
-  // https://github.com/openzipkin/zipkin/issues/1298
-  it('should drop high bits of a 128bit X-B3-TraceId', done => {
+  it('should accept a 128bit X-B3-TraceId', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
@@ -110,12 +107,13 @@ describe('restify middleware - integration test', () => {
         return next();
       });
       const server = app.listen(0, () => {
+        const traceId = '863ac35c9f6413ad48485a3953bb6124';
         const port = server.address().port;
         const url = `http://127.0.0.1:${port}/foo`;
         fetch(url, {
           method: 'post',
           headers: {
-            'X-B3-TraceId': '863ac35c9f6413ad48485a3953bb6124',
+            'X-B3-TraceId': traceId,
             'X-B3-SpanId': '48485a3953bb6124',
             'X-B3-Flags': '1'
           }
@@ -124,7 +122,7 @@ describe('restify middleware - integration test', () => {
 
           const annotations = record.args.map(args => args[0]);
 
-          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('48485a3953bb6124'));
+          annotations.forEach(ann => expect(ann.traceId.traceId).to.equal(traceId));
           done();
         })
         .catch(err => {

--- a/packages/zipkin/README.md
+++ b/packages/zipkin/README.md
@@ -17,5 +17,6 @@ const tracer = new zipkin.Tracer({
   ctxImpl,
   recorder: new zipkin.ConsoleRecorder() // For easy debugging. You probably want to use an actual implementation, like Kafka or Scribe.
   sampler: new Zipkin.CountingSampler(0.01) // sample rate 0.01 will sample 1 % of all incoming requests
+  traceId128Bit: true // to generate 128-bit trace IDs. 64-bit (false) is default
 });
 ```

--- a/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
+++ b/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
@@ -22,6 +22,7 @@ Endpoint = module.exports.Endpoint = function(args) {
   this.ipv4 = null;
   this.port = null;
   this.service_name = null;
+  this.ipv6 = null;
   if (args) {
     if (args.ipv4 !== undefined && args.ipv4 !== null) {
       this.ipv4 = args.ipv4;
@@ -31,6 +32,9 @@ Endpoint = module.exports.Endpoint = function(args) {
     }
     if (args.service_name !== undefined && args.service_name !== null) {
       this.service_name = args.service_name;
+    }
+    if (args.ipv6 !== undefined && args.ipv6 !== null) {
+      this.ipv6 = args.ipv6;
     }
   }
 };
@@ -69,6 +73,13 @@ Endpoint.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
+      case 4:
+      if (ftype == Thrift.Type.STRING) {
+        this.ipv6 = input.readBinary();
+      } else {
+        input.skip(ftype);
+      }
+      break;
       default:
         input.skip(ftype);
     }
@@ -93,6 +104,11 @@ Endpoint.prototype.write = function(output) {
   if (this.service_name !== null && this.service_name !== undefined) {
     output.writeFieldBegin('service_name', Thrift.Type.STRING, 3);
     output.writeString(this.service_name);
+    output.writeFieldEnd();
+  }
+  if (this.ipv6 !== null && this.ipv6 !== undefined) {
+    output.writeFieldBegin('ipv6', Thrift.Type.STRING, 4);
+    output.writeBinary(this.ipv6);
     output.writeFieldEnd();
   }
   output.writeFieldStop();
@@ -290,6 +306,9 @@ Span = module.exports.Span = function(args) {
   this.annotations = null;
   this.binary_annotations = null;
   this.debug = false;
+  this.timestamp = null;
+  this.duration = null;
+  this.trace_id_high = null;
   if (args) {
     if (args.trace_id !== undefined && args.trace_id !== null) {
       this.trace_id = args.trace_id;
@@ -311,6 +330,15 @@ Span = module.exports.Span = function(args) {
     }
     if (args.debug !== undefined && args.debug !== null) {
       this.debug = args.debug;
+    }
+    if (args.timestamp !== undefined && args.timestamp !== null) {
+      this.timestamp = args.timestamp;
+    }
+    if (args.duration !== undefined && args.duration !== null) {
+      this.duration = args.duration;
+    }
+    if (args.trace_id_high !== undefined && args.trace_id_high !== null) {
+      this.trace_id_high = args.trace_id_high;
     }
   }
 };
@@ -405,6 +433,27 @@ Span.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
+      case 10:
+      if (ftype == Thrift.Type.I64) {
+        this.timestamp = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 11:
+      if (ftype == Thrift.Type.I64) {
+        this.duration = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 12:
+      if (ftype == Thrift.Type.I64) {
+        this.trace_id_high = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
       default:
         input.skip(ftype);
     }
@@ -469,6 +518,21 @@ Span.prototype.write = function(output) {
     output.writeBool(this.debug);
     output.writeFieldEnd();
   }
+  if (this.timestamp !== null && this.timestamp !== undefined) {
+    output.writeFieldBegin('timestamp', Thrift.Type.I64, 10);
+    output.writeI64(this.timestamp);
+    output.writeFieldEnd();
+  }
+  if (this.duration !== null && this.duration !== undefined) {
+    output.writeFieldBegin('duration', Thrift.Type.I64, 11);
+    output.writeI64(this.duration);
+    output.writeFieldEnd();
+  }
+  if (this.trace_id_high !== null && this.trace_id_high !== undefined) {
+    output.writeFieldBegin('trace_id_high', Thrift.Type.I64, 12);
+    output.writeI64(this.trace_id_high);
+    output.writeFieldEnd();
+  }
   output.writeFieldStop();
   output.writeStructEnd();
   return;
@@ -478,4 +542,20 @@ ttypes.CLIENT_SEND = 'cs';
 ttypes.CLIENT_RECV = 'cr';
 ttypes.SERVER_SEND = 'ss';
 ttypes.SERVER_RECV = 'sr';
+ttypes.WIRE_SEND = 'ws';
+ttypes.WIRE_RECV = 'wr';
+ttypes.CLIENT_SEND_FRAGMENT = 'csf';
+ttypes.CLIENT_RECV_FRAGMENT = 'crf';
+ttypes.SERVER_SEND_FRAGMENT = 'ssf';
+ttypes.SERVER_RECV_FRAGMENT = 'srf';
+ttypes.HTTP_HOST = 'http.host';
+ttypes.HTTP_METHOD = 'http.method';
+ttypes.HTTP_PATH = 'http.path';
+ttypes.HTTP_URL = 'http.url';
+ttypes.HTTP_STATUS_CODE = 'http.status_code';
+ttypes.HTTP_REQUEST_SIZE = 'http.request.size';
+ttypes.HTTP_RESPONSE_SIZE = 'http.response.size';
+ttypes.LOCAL_COMPONENT = 'lc';
+ttypes.ERROR = 'error';
+ttypes.CLIENT_ADDR = 'ca';
 ttypes.SERVER_ADDR = 'sa';

--- a/packages/zipkin/src/internalRepresentations.js
+++ b/packages/zipkin/src/internalRepresentations.js
@@ -172,7 +172,13 @@ MutableSpan.prototype.toThrift = function toThrift() {
     span.parent_id = id;
   });
 
-  span.trace_id = this.traceId.traceId;
+  const traceId = this.traceId.traceId;
+  if (traceId.length <= 16) {
+    span.trace_id = traceId;
+  } else {
+    span.trace_id_high = traceId.substr(0, 16);
+    span.trace_id = traceId.substr(traceId.length - 16);
+  }
   span.name = this.name.getOrElse('Unknown');
   span.debug = this.traceId.isDebug();
 

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -1,21 +1,12 @@
 const {Some, None, verifyIsOptional} = require('../option');
 
-// truncates a 128 bit hex-encoded trace ID to its lower 64 bits
-function coerceTo64Bit(str) {
-  if (str.length <= 16) {
-    return str;
-  } else {
-    return str.substr(str.length - 16);
-  }
-}
-
 class TraceId {
   constructor(params) {
     const {traceId = None, parentId = None, spanId, sampled = None, flags = 0} = params;
     verifyIsOptional(traceId);
     verifyIsOptional(parentId);
     verifyIsOptional(sampled);
-    this._traceId = traceId.map(coerceTo64Bit);
+    this._traceId = traceId;
     this._parentId = parentId;
     this._spanId = spanId;
     this._sampled = sampled;

--- a/packages/zipkin/src/tracer/randomTraceId.js
+++ b/packages/zipkin/src/tracer/randomTraceId.js
@@ -1,14 +1,10 @@
-// === Generate random 64-bit number in hex format
+// === Generate a random 64-bit number in fixed-length hex format
 function randomTraceId() {
   const digits = '0123456789abcdef';
   let n = '';
   for (let i = 0; i < 16; i++) {
     const rand = Math.floor(Math.random() * 16);
-
-    // avoid leading zeroes
-    if (rand !== 0 || n.length > 0) {
-      n += digits[rand];
-    }
+    n += digits[rand];
   }
   return n;
 }

--- a/packages/zipkin/src/zipkinCore.thrift
+++ b/packages/zipkin/src/zipkinCore.thrift
@@ -1,46 +1,448 @@
 # Generate with the command "thrift -gen js:node zipkinCore.thrift"
 namespace java com.twitter.zipkin.gen
-namespace rb Zipkin
 
-#************** Collection related structs **************
-
-# these are the annotations we always expect to find in a span
+#************** Annotation.value **************
+/**
+ * The client sent ("cs") a request to a server. There is only one send per
+ * span. For example, if there's a transport error, each attempt can be logged
+ * as a WIRE_SEND annotation.
+ *
+ * If chunking is involved, each chunk could be logged as a separate
+ * CLIENT_SEND_FRAGMENT in the same span.
+ *
+ * Annotation.host is not the server. It is the host which logged the send
+ * event, almost always the client. When logging CLIENT_SEND, instrumentation
+ * should also log the SERVER_ADDR.
+ */
 const string CLIENT_SEND = "cs"
+/**
+ * The client received ("cr") a response from a server. There is only one
+ * receive per span. For example, if duplicate responses were received, each
+ * can be logged as a WIRE_RECV annotation.
+ *
+ * If chunking is involved, each chunk could be logged as a separate
+ * CLIENT_RECV_FRAGMENT in the same span.
+ *
+ * Annotation.host is not the server. It is the host which logged the receive
+ * event, almost always the client. The actual endpoint of the server is
+ * recorded separately as SERVER_ADDR when CLIENT_SEND is logged.
+ */
 const string CLIENT_RECV = "cr"
+/**
+ * The server sent ("ss") a response to a client. There is only one response
+ * per span. If there's a transport error, each attempt can be logged as a
+ * WIRE_SEND annotation.
+ *
+ * Typically, a trace ends with a server send, so the last timestamp of a trace
+ * is often the timestamp of the root span's server send.
+ *
+ * If chunking is involved, each chunk could be logged as a separate
+ * SERVER_SEND_FRAGMENT in the same span.
+ *
+ * Annotation.host is not the client. It is the host which logged the send
+ * event, almost always the server. The actual endpoint of the client is
+ * recorded separately as CLIENT_ADDR when SERVER_RECV is logged.
+ */
 const string SERVER_SEND = "ss"
+/**
+ * The server received ("sr") a request from a client. There is only one
+ * request per span.  For example, if duplicate responses were received, each
+ * can be logged as a WIRE_RECV annotation.
+ *
+ * Typically, a trace starts with a server receive, so the first timestamp of a
+ * trace is often the timestamp of the root span's server receive.
+ *
+ * If chunking is involved, each chunk could be logged as a separate
+ * SERVER_RECV_FRAGMENT in the same span.
+ *
+ * Annotation.host is not the client. It is the host which logged the receive
+ * event, almost always the server. When logging SERVER_RECV, instrumentation
+ * should also log the CLIENT_ADDR.
+ */
 const string SERVER_RECV = "sr"
+/**
+ * Optionally logs an attempt to send a message on the wire. Multiple wire send
+ * events could indicate network retries. A lag between client or server send
+ * and wire send might indicate queuing or processing delay.
+ */
+const string WIRE_SEND = "ws"
+/**
+ * Optionally logs an attempt to receive a message from the wire. Multiple wire
+ * receive events could indicate network retries. A lag between wire receive
+ * and client or server receive might indicate queuing or processing delay.
+ */
+const string WIRE_RECV = "wr"
+/**
+ * Optionally logs progress of a (CLIENT_SEND, WIRE_SEND). For example, this
+ * could be one chunk in a chunked request.
+ */
+const string CLIENT_SEND_FRAGMENT = "csf"
+/**
+ * Optionally logs progress of a (CLIENT_RECV, WIRE_RECV). For example, this
+ * could be one chunk in a chunked response.
+ */
+const string CLIENT_RECV_FRAGMENT = "crf"
+/**
+ * Optionally logs progress of a (SERVER_SEND, WIRE_SEND). For example, this
+ * could be one chunk in a chunked response.
+ */
+const string SERVER_SEND_FRAGMENT = "ssf"
+/**
+ * Optionally logs progress of a (SERVER_RECV, WIRE_RECV). For example, this
+ * could be one chunk in a chunked request.
+ */
+const string SERVER_RECV_FRAGMENT = "srf"
+
+#***** BinaryAnnotation.key ******
+/**
+ * The domain portion of the URL or host header. Ex. "mybucket.s3.amazonaws.com"
+ *
+ * Used to filter by host as opposed to ip address.
+ */
+const string HTTP_HOST = "http.host"
+
+/**
+ * The HTTP method, or verb, such as "GET" or "POST".
+ *
+ * Used to filter against an http route.
+ */
+const string HTTP_METHOD = "http.method"
+
+/**
+ * The absolute http path, without any query parameters. Ex. "/objects/abcd-ff"
+ *
+ * Used to filter against an http route, portably with zipkin v1.
+ *
+ * In zipkin v1, only equals filters are supported. Dropping query parameters makes the number
+ * of distinct URIs less. For example, one can query for the same resource, regardless of signing
+ * parameters encoded in the query line. This does not reduce cardinality to a HTTP single route.
+ * For example, it is common to express a route as an http URI template like
+ * "/resource/{resource_id}". In systems where only equals queries are available, searching for
+ * http/path=/resource won't match if the actual request was /resource/abcd-ff.
+ *
+ * Historical note: This was commonly expressed as "http.uri" in zipkin, eventhough it was most
+ * often just a path.
+ */
+const string HTTP_PATH = "http.path"
+
+/**
+ * The entire URL, including the scheme, host and query parameters if available. Ex.
+ * "https://mybucket.s3.amazonaws.com/objects/abcd-ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Algorithm=AWS4-HMAC-SHA256..."
+ *
+ * Combined with HTTP_METHOD, you can understand the fully-qualified request line.
+ *
+ * This is optional as it may include private data or be of considerable length.
+ */
+const string HTTP_URL = "http.url"
+
+/**
+ * The HTTP status code, when not in 2xx range. Ex. "503"
+ *
+ * Used to filter for error status.
+ */
+const string HTTP_STATUS_CODE = "http.status_code"
+
+/**
+ * The size of the non-empty HTTP request body, in bytes. Ex. "16384"
+ *
+ * Large uploads can exceed limits or contribute directly to latency.
+ */
+const string HTTP_REQUEST_SIZE = "http.request.size"
+
+/**
+ * The size of the non-empty HTTP response body, in bytes. Ex. "16384"
+ *
+ * Large downloads can exceed limits or contribute directly to latency.
+ */
+const string HTTP_RESPONSE_SIZE = "http.response.size"
+
+/**
+ * The value of "lc" is the component or namespace of a local span.
+ *
+ * BinaryAnnotation.host adds service context needed to support queries.
+ *
+ * Local Component("lc") supports three key features: flagging, query by
+ * service and filtering Span.name by namespace.
+ *
+ * While structurally the same, local spans are fundamentally different than
+ * RPC spans in how they should be interpreted. For example, zipkin v1 tools
+ * center on RPC latency and service graphs. Root local-spans are neither
+ * indicative of critical path RPC latency, nor have impact on the shape of a
+ * service graph. By flagging with "lc", tools can special-case local spans.
+ *
+ * Zipkin v1 Spans are unqueryable unless they can be indexed by service name.
+ * The only path to a service name is by (Binary)?Annotation.host.serviceName.
+ * By logging "lc", a local span can be queried even if no other annotations
+ * are logged.
+ *
+ * The value of "lc" is the namespace of Span.name. For example, it might be
+ * "finatra2", for a span named "bootstrap". "lc" allows you to resolves
+ * conflicts for the same Span.name, for example "finatra/bootstrap" vs
+ * "finch/bootstrap". Using local component, you'd search for spans named
+ * "bootstrap" where "lc=finch"
+ */
+const string LOCAL_COMPONENT = "lc"
+
+#***** Annotation.value or BinaryAnnotation.key ******
+/**
+ * When an annotation value, this indicates when an error occurred. When a
+ * binary annotation key, the value is a human readable message associated
+ * with an error.
+ *
+ * Due to transient errors, an ERROR annotation should not be interpreted
+ * as a span failure, even the annotation might explain additional latency.
+ * Instrumentation should add the ERROR binary annotation when the operation
+ * failed and couldn't be recovered.
+ *
+ * Here's an example: A span has an ERROR annotation, added when a WIRE_SEND
+ * failed. Another WIRE_SEND succeeded, so there's no ERROR binary annotation
+ * on the span because the overall operation succeeded.
+ *
+ * Note that RPC spans often include both client and server hosts: It is
+ * possible that only one side perceived the error.
+ */
+const string ERROR = "error"
+
+#***** BinaryAnnotation.key where value = [1] and annotation_type = BOOL ******
+/**
+ * Indicates a client address ("ca") in a span. Most likely, there's only one.
+ * Multiple addresses are possible when a client changes its ip or port within
+ * a span.
+ */
+const string CLIENT_ADDR = "ca"
+/**
+ * Indicates a server address ("sa") in a span. Most likely, there's only one.
+ * Multiple addresses are possible when a client is redirected, or fails to a
+ * different server ip or port.
+ */
 const string SERVER_ADDR = "sa"
 
-# this represents a host and port in a network
+/**
+ * Indicates the network context of a service recording an annotation with two
+ * exceptions.
+ *
+ * When a BinaryAnnotation, and key is CLIENT_ADDR or SERVER_ADDR,
+ * the endpoint indicates the source or destination of an RPC. This exception
+ * allows zipkin to display network context of uninstrumented services, or
+ * clients such as web browsers.
+ */
 struct Endpoint {
-  1: i32 ipv4,
-  2: i16 port                      # beware that this will give us negative ports. some conversion needed
-  3: string service_name           # which service did this operation happen on?
+  /**
+   * IPv4 host address packed into 4 bytes.
+   *
+   * Ex for the ip 1.2.3.4, it would be (1 << 24) | (2 << 16) | (3 << 8) | 4
+   */
+  1: i32 ipv4
+  /**
+   * IPv4 port or 0, if unknown.
+   *
+   * Note: this is to be treated as an unsigned integer, so watch for negatives.
+   */
+  2: i16 port
+  /**
+   * Classifier of a source or destination in lowercase, such as "zipkin-web".
+   *
+   * This is the primary parameter for trace lookup, so should be intuitive as
+   * possible, for example, matching names in service discovery.
+   *
+   * Conventionally, when the service name isn't known, service_name = "unknown".
+   * However, it is also permissible to set service_name = "" (empty string).
+   * The difference in the latter usage is that the span will not be queryable
+   * by service name unless more information is added to the span with non-empty
+   * service name, e.g. an additional annotation from the server.
+   *
+   * Particularly clients may not have a reliable service name at ingest. One
+   * approach is to set service_name to "" at ingest, and later assign a
+   * better label based on binary annotations, such as user agent.
+   */
+  3: string service_name
+  /**
+   * IPv6 host address packed into 16 bytes. Ex Inet6Address.getBytes()
+   */
+  4: optional binary ipv6
 }
 
-# some event took place, either one by the framework or by the user
+/**
+ * Associates an event that explains latency with a timestamp.
+ *
+ * Unlike log statements, annotations are often codes: for example "sr".
+ */
 struct Annotation {
-  1: i64 timestamp                 # microseconds from epoch
-  2: string value                  # what happened at the timestamp?
-  3: optional Endpoint host        # host this happened on
+  /**
+   * Microseconds from epoch.
+   *
+   * This value should use the most precise value possible. For example,
+   * gettimeofday or multiplying currentTimeMillis by 1000.
+   */
+  1: i64 timestamp
+  /**
+   * Usually a short tag indicating an event, like "sr" or "finagle.retry".
+   */
+  2: string value
+  /**
+   * The host that recorded the value, primarily for query by service name.
+   */
+  3: optional Endpoint host
   // don't reuse 4: optional i32 OBSOLETE_duration         // how long did the operation take? microseconds
 }
 
-enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }
+/**
+ * A subset of thrift base types, except BYTES.
+ */
+enum AnnotationType {
+  /**
+   * Set to 0x01 when key is CLIENT_ADDR or SERVER_ADDR
+   */
+  BOOL,
+  /**
+   * No encoding, or type is unknown.
+   */
+  BYTES,
+  I16,
+  I32,
+  I64,
+  DOUBLE,
+  /**
+   * the only type zipkin v1 supports search against.
+   */
+  STRING
+}
 
+/**
+ * Binary annotations are tags applied to a Span to give it context. For
+ * example, a binary annotation of HTTP_PATH ("http.path") could the path
+ * to a resource in a RPC call.
+ *
+ * Binary annotations of type STRING are always queryable, though more a
+ * historical implementation detail than a structural concern.
+ *
+ * Binary annotations can repeat, and vary on the host. Similar to Annotation,
+ * the host indicates who logged the event. This allows you to tell the
+ * difference between the client and server side of the same key. For example,
+ * the key "http.path" might be different on the client and server side due to
+ * rewriting, like "/api/v1/myresource" vs "/myresource. Via the host field,
+ * you can see the different points of view, which often help in debugging.
+ */
 struct BinaryAnnotation {
+  /**
+   * Name used to lookup spans, such as "http.path" or "finagle.version".
+   */
   1: string key,
+  /**
+   * Serialized thrift bytes, in TBinaryProtocol format.
+   *
+   * For legacy reasons, byte order is big-endian. See THRIFT-3217.
+   */
   2: binary value,
+  /**
+   * The thrift type of value, most often STRING.
+   *
+   * annotation_type shouldn't vary for the same key.
+   */
   3: AnnotationType annotation_type,
+  /**
+   * The host that recorded value, allowing query by service name or address.
+   *
+   * There are two exceptions: when key is "ca" or "sa", this is the source or
+   * destination of an RPC. This exception allows zipkin to display network
+   * context of uninstrumented services, such as browsers or databases.
+   */
   4: optional Endpoint host
 }
 
+/**
+ * A trace is a series of spans (often RPC calls) which form a latency tree.
+ *
+ * Spans are usually created by instrumentation in RPC clients or servers, but
+ * can also represent in-process activity. Annotations in spans are similar to
+ * log statements, and are sometimes created directly by application developers
+ * to indicate events of interest, such as a cache miss.
+ *
+ * The root span is where parent_id = Nil; it usually has the longest duration
+ * in the trace.
+ *
+ * Span identifiers are packed into i64s, but should be treated opaquely.
+ * String encoding is fixed-width lower-hex, to avoid signed interpretation.
+ */
 struct Span {
-  1: i64 trace_id                  # unique trace id, use for all spans in trace
-  3: string name,                  # span name, rpc method for example
-  4: i64 id,                       # unique span id, only used for this span
-  5: optional i64 parent_id,                # parent span id
-  6: list<Annotation> annotations, # list of all annotations/events that occured
-  8: list<BinaryAnnotation> binary_annotations # any binary annotations
-  9: optional bool debug = 0       # if true, we DEMAND that this span passes all samplers
+  /**
+   * Unique 8-byte identifier for a trace, set on all spans within it.
+   */
+  1: i64 trace_id
+  /**
+   * Span name in lowercase, rpc method for example. Conventionally, when the
+   * span name isn't known, name = "unknown".
+   */
+  3: string name,
+  /**
+   * Unique 8-byte identifier of this span within a trace. A span is uniquely
+   * identified in storage by (trace_id, id).
+   */
+  4: i64 id,
+  /**
+   * The parent's Span.id; absent if this the root span in a trace.
+   */
+  5: optional i64 parent_id,
+  /**
+   * Associates events that explain latency with a timestamp. Unlike log
+   * statements, annotations are often codes: for example SERVER_RECV("sr").
+   * Annotations are sorted ascending by timestamp.
+   */
+  6: list<Annotation> annotations,
+  /**
+   * Tags a span with context, usually to support query or aggregation. For
+   * example, a binary annotation key could be "http.path".
+   */
+  8: list<BinaryAnnotation> binary_annotations
+  /**
+   * True is a request to store this span even if it overrides sampling policy.
+   */
+  9: optional bool debug = 0
+  /**
+   * Epoch microseconds of the start of this span, absent if this an incomplete
+   * span.
+   *
+   * This value should be set directly by instrumentation, using the most
+   * precise value possible. For example, gettimeofday or syncing nanoTime
+   * against a tick of currentTimeMillis.
+   *
+   * For compatibilty with instrumentation that precede this field, collectors
+   * or span stores can derive this via Annotation.timestamp.
+   * For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
+   *
+   * Timestamp is nullable for input only. Spans without a timestamp cannot be
+   * presented in a timeline: Span stores should not output spans missing a
+   * timestamp.
+   *
+   * There are two known edge-cases where this could be absent: both cases
+   * exist when a collector receives a span in parts and a binary annotation
+   * precedes a timestamp. This is possible when..
+   *  - The span is in-flight (ex not yet received a timestamp)
+   *  - The span's start event was lost
+   */
+  10: optional i64 timestamp,
+  /**
+   * Measurement in microseconds of the critical path, if known. Durations of
+   * less than one microsecond must be rounded up to 1 microsecond.
+   *
+   * This value should be set directly, as opposed to implicitly via annotation
+   * timestamps. Doing so encourages precision decoupled from problems of
+   * clocks, such as skew or NTP updates causing time to move backwards.
+   *
+   * For compatibility with instrumentation that precede this field, collectors
+   * or span stores can derive this by subtracting Annotation.timestamp.
+   * For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
+   *
+   * If this field is persisted as unset, zipkin will continue to work, except
+   * duration query support will be implementation-specific. Similarly, setting
+   * this field non-atomically is implementation-specific.
+   *
+   * This field is i64 vs i32 to support spans longer than 35 minutes.
+   */
+  11: optional i64 duration
+  /**
+   * Optional unique 8-byte additional identifier for a trace. If non zero, this
+   * means the trace uses 128 bit traceIds instead of 64 bit.
+   */
+  12: optional i64 trace_id_high
 }

--- a/packages/zipkin/test/TraceId.test.js
+++ b/packages/zipkin/test/TraceId.test.js
@@ -2,7 +2,7 @@ const {Some} = require('../src/option');
 const TraceId = require('../src/tracer/TraceId');
 
 describe('TraceId', () => {
-  it('should leave 64bit trace ids alone', () => {
+  it('should accept a 64bit trace id', () => {
     const traceId = new TraceId({
       traceId: new Some('48485a3953bb6124'),
       spanId: '48485a3953bb6124'
@@ -10,11 +10,11 @@ describe('TraceId', () => {
     expect(traceId.traceId).to.equal('48485a3953bb6124');
   });
 
-  it('should drop high bits of a 128bit trace id', () => {
+  it('should accept a 128bit trace id', () => {
     const traceId = new TraceId({
       traceId: new Some('863ac35c9f6413ad48485a3953bb6124'),
       spanId: '48485a3953bb6124'
     });
-    expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.traceId).to.equal('863ac35c9f6413ad48485a3953bb6124');
   });
 });

--- a/packages/zipkin/test/randomTraceId.test.js
+++ b/packages/zipkin/test/randomTraceId.test.js
@@ -1,10 +1,10 @@
 const randomTraceId = require('../src/tracer/randomTraceId');
 
 describe('random trace id', () => {
-  it('should never have leading zeroes', () => {
+  it('should have fixed length of 16 characters', () => {
     for (let i = 0; i < 100; i++) {
       const rand = randomTraceId();
-      expect(rand.startsWith('0')).to.equal(false);
+      expect(rand.length).to.equal(16);
     }
   });
 });

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -82,4 +82,26 @@ describe('Tracer', () => {
     });
     clock.uninstall();
   });
+
+  it('should create fixed-length 64-bit trace ID by default', () => {
+    const recorder = {
+      record: () => {}
+    };
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({ctxImpl, recorder});
+
+    const rootTracerId = tracer.createRootId();
+    expect(rootTracerId.traceId.length).to.eql(16);
+  });
+
+  it('should create fixed-length 128-bit trace ID on traceId128Bit', () => {
+    const recorder = {
+      record: () => {}
+    };
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({ctxImpl, recorder, traceId128Bit: true});
+
+    const rootTracerId = tracer.createRootId();
+    expect(rootTracerId.traceId.length).to.eql(32);
+  });
 });


### PR DESCRIPTION
Before, we threw out high bits when receiving 128-bit trace IDs. This
retains and reports them to Zipkin.

When a Tracer is initialized with `traceId128Bit: true`, the trace IDs
will be 128-bit (32 characters) as opposed to 64-bit. In either case,
span IDs within a trace are 64-bit (16 characters).

To simplify things, this does away with variable length ID generation
in favor of the de-facto fixed length. It is unlikely that random
numbers would have a lot of leading zeros to optimize out anyway.