### PR TITLE
BathRecorder: Do hostname IPv4 lookup before annotating span with Endpoint

### DIFF
--- a/packages/zipkin/src/InetAddress.js
+++ b/packages/zipkin/src/InetAddress.js
@@ -1,3 +1,5 @@
+const dns = require('dns');
+const net = require('net');
 const networkAddress = require('network-address');
 
 class InetAddress {
@@ -22,6 +24,26 @@ class InetAddress {
 
 InetAddress.getLocalAddress = function getLocalAddress() {
   return new InetAddress(networkAddress.ipv4());
+};
+
+InetAddress.getAddressByName = function getAddressByName(host, callback) {
+  if (!host) {
+    callback(0);
+  } else if (host instanceof InetAddress) {
+    callback(host);
+  } else if (net.isIPv4(host)) {
+    callback(new InetAddress(host));
+  } else {
+    // only IPv4 addresses are supported by `InetAddress`,
+    // so restrict the lookup call to `family: 4` only
+    dns.lookup(host, {family: 4}, (err, addr) => {
+      if (err !== null) {
+        callback(0);
+        return;
+      }
+      callback(new InetAddress(addr));
+    });
+  }
 };
 
 module.exports = InetAddress;

--- a/packages/zipkin/src/internalRepresentations.js
+++ b/packages/zipkin/src/internalRepresentations.js
@@ -1,8 +1,9 @@
 const thriftTypes = require('./gen-nodejs/zipkinCore_types');
 const {now, hrtime} = require('./time');
 const {Some, None} = require('./option');
+const {getAddressByName} = require('./InetAddress');
 
-function Endpoint({serviceName, host, port}) {
+function Endpoint({serviceName, host, port} = {}) {
   this.serviceName = serviceName;
   this.host = host || 0;
   this.port = port || 0;
@@ -27,6 +28,17 @@ Endpoint.prototype.toJSON = function toJSON() {
     ipv4: formatIPv4(this.host),
     port: this.port
   };
+};
+
+Endpoint.createEndpoint = function createEndpoint({serviceName, host, port}, callback) {
+  getAddressByName(host, addr => {
+    const ep = new Endpoint({
+      serviceName,
+      host: addr ? addr.toInt() : addr,
+      port,
+    });
+    callback(ep);
+  });
 };
 
 function ZipkinAnnotation({timestamp, value, endpoint}) {
@@ -116,7 +128,7 @@ function MutableSpan(traceId) {
   this.startTick = hrtime();
   this.name = None;
   this.service = None;
-  this.endpoint = new Endpoint({});
+  this.endpoint = new Endpoint();
   this.serverAddr = None;
   this.annotations = [];
   this.binaryAnnotations = [];

--- a/packages/zipkin/test/InetAddress.test.js
+++ b/packages/zipkin/test/InetAddress.test.js
@@ -13,4 +13,26 @@ describe('InetAddress', () => {
     const addr = new InetAddress('80.91.37.133');
     expect(addr.toString()).to.equal('InetAddress(80.91.37.133)');
   });
+
+  it('should get the address by hostname', done => {
+    InetAddress.getAddressByName('localhost', addr => {
+      expect(addr).to.be.an.instanceof(InetAddress);
+      done();
+    });
+  });
+
+  it('should get the address by IPv4 address', done => {
+    InetAddress.getAddressByName('80.91.37.133', addr => {
+      expect(addr.toInt()).to.equal(1348150661);
+      done();
+    });
+  });
+
+  it('should get the address by InetAddress instance', done => {
+    const inetAddr = new InetAddress('80.91.37.133');
+    InetAddress.getAddressByName(inetAddr, addr => {
+      expect(addr.toInt()).to.equal(1348150661);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces an ability to use hostnames in `LocalAddr` and `ServerAddr` annotations instead of `InetAddr` instanses.

Since now on `BathRecorder` uses `Endpoint.createEndpoint()` factory, which do async IPv4 lookup (in case hostname was passed as `host`), before creating an `Endpoint` instance. While API of `BathRecorder` stayed the same, it's `record()` method is doing MutableSpan uptation asyncronosly, now.

closes #58
