### PR TITLE
Modify generated thrift files to fix global object leak

### DIFF
--- a/packages/zipkin-transport-scribe/test/gen-nodejs/scribe.js
+++ b/packages/zipkin-transport-scribe/test/gen-nodejs/scribe.js
@@ -11,7 +11,7 @@ var Q = thrift.Q;
 var ttypes = require('./scribeServer_types');
 //HELPER FUNCTIONS AND STRUCTURES
 
-scribe_Log_args = function(args) {
+var scribe_Log_args = function(args) {
   this.messages = null;
   if (args) {
     if (args.messages !== undefined && args.messages !== null) {
@@ -87,7 +87,7 @@ scribe_Log_args.prototype.write = function(output) {
   return;
 };
 
-scribe_Log_result = function(args) {
+var scribe_Log_result = function(args) {
   this.success = null;
   if (args) {
     if (args.success !== undefined && args.success !== null) {
@@ -140,7 +140,7 @@ scribe_Log_result.prototype.write = function(output) {
   return;
 };
 
-scribeClient = exports.Client = function(output, pClass) {
+var scribeClient = exports.Client = function(output, pClass) {
     this.output = output;
     this.pClass = pClass;
     this._seqid = 0;
@@ -196,7 +196,7 @@ scribeClient.prototype.recv_Log = function(input,mtype,rseqid) {
   }
   return callback('Log failed: unknown result');
 };
-scribeProcessor = exports.Processor = function(handler) {
+var scribeProcessor = exports.Processor = function(handler) {
   this._handler = handler
 }
 scribeProcessor.prototype.process = function(input, output) {

--- a/packages/zipkin-transport-scribe/test/gen-nodejs/scribeServer_types.js
+++ b/packages/zipkin-transport-scribe/test/gen-nodejs/scribeServer_types.js
@@ -13,7 +13,7 @@ ttypes.ResultCode = {
   'OK' : 0,
   'TRY_LATER' : 1
 };
-LogEntry = module.exports.LogEntry = function(args) {
+var LogEntry = module.exports.LogEntry = function(args) {
   this.category = null;
   this.message = null;
   if (args) {

--- a/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
+++ b/packages/zipkin/src/gen-nodejs/zipkinCore_types.js
@@ -18,7 +18,7 @@ ttypes.AnnotationType = {
   'DOUBLE' : 5,
   'STRING' : 6
 };
-Endpoint = module.exports.Endpoint = function(args) {
+var Endpoint = module.exports.Endpoint = function(args) {
   this.ipv4 = null;
   this.port = null;
   this.service_name = null;
@@ -116,7 +116,7 @@ Endpoint.prototype.write = function(output) {
   return;
 };
 
-Annotation = module.exports.Annotation = function(args) {
+var Annotation = module.exports.Annotation = function(args) {
   this.timestamp = null;
   this.value = null;
   this.host = null;
@@ -199,7 +199,7 @@ Annotation.prototype.write = function(output) {
   return;
 };
 
-BinaryAnnotation = module.exports.BinaryAnnotation = function(args) {
+var BinaryAnnotation = module.exports.BinaryAnnotation = function(args) {
   this.key = null;
   this.value = null;
   this.annotation_type = null;
@@ -298,7 +298,7 @@ BinaryAnnotation.prototype.write = function(output) {
   return;
 };
 
-Span = module.exports.Span = function(args) {
+var Span = module.exports.Span = function(args) {
   this.trace_id = null;
   this.name = null;
   this.id = null;


### PR DESCRIPTION
Because of [a bug in the thrift compiler](https://issues.apache.org/jira/browse/THRIFT-1840), it generates javascript that leaks objects into the global context. This patch simply edits the generated thrift files to fix that ( hopefully all of them ).