### PR TITLE
Added http.req_id

### DIFF
--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -70,6 +70,7 @@ module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', po
 
       tracer.recordServiceName(serviceName);
       tracer.recordRpc(req.method);
+      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordBinary('http.url', url.format({
         protocol: req.isSecure() ? 'https' : 'http',
         host: req.header('host'),

--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -70,12 +70,12 @@ module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', po
 
       tracer.recordServiceName(serviceName);
       tracer.recordRpc(req.method);
-      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordBinary('http.url', url.format({
         protocol: req.isSecure() ? 'https' : 'http',
         host: req.header('host'),
         pathname: req.path()
       }));
+      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordAnnotation(new Annotation.ServerRecv());
       tracer.recordAnnotation(new Annotation.LocalAddr({port}));
 


### PR DESCRIPTION
This would make finding a specific trace much more easy since it we can just query for `http.req_id=…` in the UI.