### PR TITLE
Added http.req_id annotation to restify middleware

### DIFF
--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -70,6 +70,7 @@ module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', po
 
       tracer.recordServiceName(serviceName);
       tracer.recordRpc(req.method);
+      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordBinary('http.url', url.format({
         protocol: req.isSecure() ? 'https' : 'http',
         host: req.header('host'),

--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -70,12 +70,12 @@ module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', po
 
       tracer.recordServiceName(serviceName);
       tracer.recordRpc(req.method);
-      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordBinary('http.url', url.format({
         protocol: req.isSecure() ? 'https' : 'http',
         host: req.header('host'),
         pathname: req.path()
       }));
+      tracer.recordBinary('http.req_id', req.getId());
       tracer.recordAnnotation(new Annotation.ServerRecv());
       tracer.recordAnnotation(new Annotation.LocalAddr({port}));
 

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -55,9 +55,9 @@ describe('restify middleware - integration test', () => {
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
           expect(annotations[2].annotation.key).to.equal('http.url');
           expect(annotations[2].annotation.value).to.equal(url);
-          
+
           expect(annotations[3].annotation.key).to.equal('http.req_id');
-          
+
           expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
           expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -55,24 +55,26 @@ describe('restify middleware - integration test', () => {
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
           expect(annotations[2].annotation.key).to.equal('http.url');
           expect(annotations[2].annotation.value).to.equal(url);
+          
+          expect(annotations[3].annotation.key).to.equal('http.req_id');
+          
+          expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
-
-          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
-
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('X-B3-Flags');
-          expect(annotations[5].annotation.value).to.equal('1');
+          expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
           expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('message');
-          expect(annotations[6].annotation.value).to.equal('hello from within app');
+          expect(annotations[6].annotation.key).to.equal('X-B3-Flags');
+          expect(annotations[6].annotation.value).to.equal('1');
 
           expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[7].annotation.key).to.equal('http.status_code');
-          expect(annotations[7].annotation.value).to.equal('202');
+          expect(annotations[7].annotation.key).to.equal('message');
+          expect(annotations[7].annotation.value).to.equal('hello from within app');
 
-          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+          expect(annotations[8].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[8].annotation.key).to.equal('http.status_code');
+          expect(annotations[8].annotation.value).to.equal('202');
+
+          expect(annotations[9].annotation.annotationType).to.equal('ServerSend');
           done();
         })
         .catch(err => {


### PR DESCRIPTION
This would allow us to much easier find the trace in UI by just searching for `http.req_id=…`.