### PR TITLE
Fix crash when hapi responds with error

### DIFF
--- a/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
+++ b/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
@@ -93,10 +93,11 @@ exports.register = (server, {tracer, serviceName = 'unknown', port = 0}, next) =
 
   server.ext('onPreResponse', (request, reply) => {
     const {response} = request;
+    const statusCode = response.isBoom ? response.output.statusCode : response.statusCode;
 
     tracer.scoped(() => {
       tracer.setId(request.plugins.zipkin.traceId);
-      tracer.recordBinary('http.status_code', response.statusCode.toString());
+      tracer.recordBinary('http.status_code', statusCode.toString());
       tracer.recordAnnotation(new Annotation.ServerSend());
     });
 


### PR DESCRIPTION
In hapi, you can respond with an error, which will be wrapped by [Boom](https://github.com/hapijs/boom). In this case, `response.statusCode` is undefined, since `response` is an instance of a Boom error.

Currently, it crashes when going to a route that produces an error (such as a 404) due to calling `toString()` on undefined. This PR fixes this by checking if the response is a Boom instance and retrieving the status code from that.