### PR TITLE
Slashes: true to resolve url format breaking changes between node v6/7

### DIFF
--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -8,7 +8,8 @@ function formatRequestUrl(proxyReq) {
     hostname: proxyReq.hostname,
     port: proxyReq.port,
     pathname: parsedPath.pathname,
-    search: parsedPath.search
+    search: parsedPath.search,
+    slashes: true // https://github.com/nodejs/node/issues/11103
   });
 }
 


### PR DESCRIPTION
Node url changed its formatting between v6 and 7. See https://github.com/nodejs/node/issues/11103

This will maintain backwards compatibility with 6 and 7. @rexxars 