### PR TITLE
Add check if decorateRequest/intercept are not defined.

### DIFF
--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -92,6 +92,71 @@ describe('express http proxy instrumentation - integration test', () => {
     });
   });
 
+  it('should create decorateRequest and intercept functions if they do not exist', done => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({recorder, ctxImpl});
+
+    tracer.scoped(() => {
+      const serviceName = 'weather-app';
+      const remoteServiceName = 'weather-api';
+
+      const apiServer = api.listen(0, () => {
+        const app = express();
+        const apiPort = apiServer.address().port;
+
+        const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
+
+        app.use(zipkinProxy(`127.0.0.1:${apiPort}`));
+
+        const appServer = app.listen(0, () => {
+          const appPort = appServer.address().port;
+          const url = `http://127.0.0.1:${appPort}/weather?index=10&count=300`;
+          fetch(url)
+            .then(res => res.json())
+            .then(() => {
+              appServer.close();
+
+              const annotations = record.args.map(args => args[0]);
+              const initialTraceId = annotations[0].traceId.traceId;
+              annotations.forEach(ann =>
+                expect(ann.traceId.traceId)
+                  .to.equal(initialTraceId).and
+                  .to.have.lengthOf(16));
+
+              expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+              expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+              expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+              expect(annotations[1].annotation.name).to.equal('GET');
+
+              expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[2].annotation.key).to.equal('http.url');
+              // express-http-proxy does not include protocol when intercepting request
+              const apiUrlWithoutProtocol = `//127.0.0.1:${apiPort}/weather?index=10&count=300`;
+              expect(annotations[2].annotation.value).to.equal(apiUrlWithoutProtocol);
+
+              expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+              expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+              expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[5].annotation.key).to.equal('http.status_code');
+              expect(annotations[5].annotation.value).to.equal('202');
+
+              expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+              done();
+            })
+            .catch(err => {
+              appServer.close();
+              done(err);
+            });
+        });
+      });
+    });
+  });
+
   it('should work in conjunction with express middleware and zipkin-context-cls', done => {
     const record = sinon.spy();
     const recorder = {record};


### PR DESCRIPTION
Got ahead of myself and missed the base test case. Added.

This was failing when `wrappedOptions.decorateRequest` and/or `wrappedOptions.intercept` were not defined.