### PR TITLE
Feature/request instrumentation

### DIFF
--- a/packages/zipkin-instrumentation-request/README.md
+++ b/packages/zipkin-instrumentation-request/README.md
@@ -1,0 +1,29 @@
+# zipkin-instrumentation-request
+
+Adds Zipkin tracing to the [request](https://www.npmjs.com/package/request) library.
+
+## Usage
+
+```javascript
+const express = require('express');
+const {Tracer, ExplicitContext, ConsoleRecorder} = require('zipkin');
+const wrapRequest = require('zipkin-instrumentation-request');
+const request = request('request');
+
+const ctxImpl = new ExplicitContext();
+const recorder = new ConsoleRecorder();
+const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+
+const serviceName = 'weather-app';
+const remoteServiceName = 'weather-api';
+const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+
+zipkinRequest({
+    url: 'http://api.weather.com',
+    method: 'GET',
+  }, function(error, response, body) {
+    console.log('error:', error);
+    console.log('statusCode:', response && response.statusCode);
+    console.log('body:', body);
+  });
+```

--- a/packages/zipkin-instrumentation-request/package.json
+++ b/packages/zipkin-instrumentation-request/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "zipkin-instrumentation-express",
+  "name": "zipkin-instrumentation-request",
   "version": "0.6.2",
-  "description": "Express middleware for instrumentation with Zipkin.js",
+  "description": "Instrumentation for request with Zipkin.js",
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",

--- a/packages/zipkin-instrumentation-request/package.json
+++ b/packages/zipkin-instrumentation-request/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "zipkin-instrumentation-express",
+  "version": "0.6.2",
+  "description": "Express middleware for instrumentation with Zipkin.js",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "babel src -d lib",
+    "test": "mocha --require ../../test/helper.js",
+    "prepublish": "npm run build"
+  },
+  "author": "OpenZipkin <openzipkin.alt@gmail.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "express": "^4.13.4",
+    "mocha": "^3.2.0",
+    "request": "^2.81.0",
+    "zipkin": "^0.6.1"
+  }
+}

--- a/packages/zipkin-instrumentation-request/src/index.js
+++ b/packages/zipkin-instrumentation-request/src/index.js
@@ -1,0 +1,3 @@
+const wrapRequest = require('./wrapRequest');
+
+module.exports = wrapRequest;

--- a/packages/zipkin-instrumentation-request/src/index.js
+++ b/packages/zipkin-instrumentation-request/src/index.js
@@ -1,3 +1,1 @@
-const wrapRequest = require('./wrapRequest');
-
-module.exports = wrapRequest;
+module.exports = require('./wrapRequest');

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -14,8 +14,7 @@ function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceNam
       tracer.recordAnnotation(new Annotation.ClientSend());
       if (remoteServiceName) {
         tracer.recordAnnotation(new Annotation.ServerAddr({
-          serviceName: remoteServiceName,
-          port: wrappedOptions.port
+          serviceName: remoteServiceName
         }));
       }
 

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -1,0 +1,34 @@
+const {Request, Annotation} = require('zipkin');
+
+function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceName}) {
+  return request.defaults((options, callback) => {
+    tracer.scoped(() => {
+      tracer.setId(tracer.createChildId());
+      const traceId = tracer.id;
+
+      const wrappedOptions = Request.addZipkinHeaders(options, tracer.id);
+      tracer.recordServiceName(serviceName);
+      const method = wrappedOptions.method || 'GET';
+      tracer.recordRpc(method.toUpperCase());
+      tracer.recordBinary('http.url', wrappedOptions.uri);
+      tracer.recordAnnotation(new Annotation.ClientSend());
+      if (remoteServiceName) {
+        tracer.recordAnnotation(new Annotation.ServerAddr({
+          serviceName: remoteServiceName,
+          port: wrappedOptions.port
+        }));
+      }
+
+      const wrappedCallback = (error, response, body) => {
+        tracer.setId(traceId);
+        tracer.recordBinary('http.status_code', response.statusCode.toString());
+        tracer.recordAnnotation(new Annotation.ClientRecv());
+        return callback(error, response, body);
+      };
+
+      request(wrappedOptions, wrappedCallback);
+    });
+  });
+}
+
+module.exports = wrapRequest;

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -10,7 +10,7 @@ function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceNam
       tracer.recordServiceName(serviceName);
       const method = wrappedOptions.method || 'GET';
       tracer.recordRpc(method.toUpperCase());
-      tracer.recordBinary('http.url', wrappedOptions.uri);
+      tracer.recordBinary('http.url', wrappedOptions.uri || wrappedOptions.url);
       tracer.recordAnnotation(new Annotation.ClientSend());
       if (remoteServiceName) {
         tracer.recordAnnotation(new Annotation.ServerAddr({

--- a/packages/zipkin-instrumentation-request/test/.eslintrc
+++ b/packages/zipkin-instrumentation-request/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true
+  }
+}

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -5,20 +5,66 @@ const sinon = require('sinon');
 const wrapRequest = require('../src/wrapRequest');
 
 describe('request instrumentation - integration test', () => {
-  const api = express();
-  api.use('/weather', (req, res) => {
-    res.status(202).json({
-      traceId: req.header('X-B3-TraceId'),
-      spanId: req.header('X-B3-SpanId')
+  let api;
+  before(() => {
+    api = express();
+    api.use('/weather', (req, res) => {
+      res.status(202).json({
+        traceId: req.header('X-B3-TraceId'),
+        spanId: req.header('X-B3-SpanId')
+      });
     });
   });
 
-  it('should add headers to requests', done => {
-    const record = sinon.spy();
-    const recorder = {record};
-    const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+  let record, recorder, ctxImpl, tracer;
+  beforeEach(() => {
+    record = sinon.spy();
+    recorder = {record};
+    ctxImpl = new ExplicitContext();
+    tracer = new Tracer({recorder, ctxImpl});
+  });
 
+  it('should add headers to requests', done => {
+    tracer.scoped(() => {
+      const serviceName = 'weather-app';
+      const remoteServiceName = 'weather-api';
+
+      const apiServer = api.listen(0, () => {
+        const apiPort = apiServer.address().port;
+        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        zipkinRequest.get(url, () => {
+          const annotations = record.args.map(args => args[0]);
+          const initialTraceId = annotations[0].traceId.traceId;
+          annotations.forEach(ann => expect(ann.traceId.traceId)
+            .to.equal(initialTraceId).and
+            .to.have.lengthOf(16));
+
+          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+          expect(annotations[1].annotation.name).to.equal('GET');
+
+          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[2].annotation.key).to.equal('http.url');
+          expect(annotations[2].annotation.value).to.equal(url);
+
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
+
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          done();
+        });
+      });
+    });
+  });
+  it('should support request shorthand (defaults to GET)', done => {
     tracer.scoped(() => {
       const serviceName = 'weather-app';
       const remoteServiceName = 'weather-api';
@@ -28,6 +74,46 @@ describe('request instrumentation - integration test', () => {
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
         const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
         zipkinRequest(url, () => {
+          const annotations = record.args.map(args => args[0]);
+          const initialTraceId = annotations[0].traceId.traceId;
+          annotations.forEach(ann => expect(ann.traceId.traceId)
+            .to.equal(initialTraceId).and
+            .to.have.lengthOf(16));
+
+          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+          expect(annotations[1].annotation.name).to.equal('GET');
+
+          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[2].annotation.key).to.equal('http.url');
+          expect(annotations[2].annotation.value).to.equal(url);
+
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
+
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          done();
+        });
+      });
+    });
+  });
+  it('should support both url and uri options', done => {
+    tracer.scoped(() => {
+      const serviceName = 'weather-app';
+      const remoteServiceName = 'weather-api';
+
+      const apiServer = api.listen(0, () => {
+        const apiPort = apiServer.address().port;
+        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        zipkinRequest({url}, () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
           annotations.forEach(ann => expect(ann.traceId.traceId)

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -1,0 +1,61 @@
+const {Tracer, ExplicitContext} = require('zipkin');
+const express = require('express');
+const request = require('request');
+const sinon = require('sinon');
+const wrapRequest = require('../src/wrapRequest');
+
+describe('request instrumentation - integration test', () => {
+  const api = express();
+  api.use('/weather', (req, res) => {
+    res.status(202).json({
+      traceId: req.header('X-B3-TraceId'),
+      spanId: req.header('X-B3-SpanId')
+    });
+  });
+
+  it('should add headers to requests', done => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({recorder, ctxImpl});
+
+    tracer.scoped(() => {
+      const serviceName = 'weather-app';
+      const remoteServiceName = 'weather-api';
+
+      const apiServer = api.listen(0, () => {
+        const apiPort = apiServer.address().port;
+        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        zipkinRequest(url, {json: true}, () => {
+          const annotations = record.args.map(args => args[0]);
+          const initialTraceId = annotations[0].traceId.traceId;
+          annotations.forEach(ann => expect(ann.traceId.traceId)
+            .to.equal(initialTraceId).and
+            .to.have.lengthOf(16));
+
+          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+          expect(annotations[1].annotation.name).to.equal('GET');
+
+          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[2].annotation.key).to.equal('http.url');
+          expect(annotations[2].annotation.value).to.equal(url);
+
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
+
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          done();
+        });
+      });
+    });
+  });
+});

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -16,7 +16,10 @@ describe('request instrumentation - integration test', () => {
     });
   });
 
-  let record, recorder, ctxImpl, tracer;
+  let record;
+  let recorder;
+  let ctxImpl;
+  let tracer;
   beforeEach(() => {
     record = sinon.spy();
     recorder = {record};

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -27,7 +27,7 @@ describe('request instrumentation - integration test', () => {
         const apiPort = apiServer.address().port;
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
         const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
-        zipkinRequest(url, {json: true}, () => {
+        zipkinRequest(url, () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
           annotations.forEach(ann => expect(ann.traceId.traceId)


### PR DESCRIPTION
Adds instrumentation for https://github.com/request/request

Appreciate feedback. This is a preliminary attempt at instrumenting request. I was struggling to figure out a good way to clean it up and share the trace id between the request and response. Seems to be a lot of duplicate code between client instrumentations.
