### PR TITLE
BugFix

### DIFF
--- a/packages/zipkin-instrumentation-redis/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-redis/src/zipkinClient.js
@@ -1,4 +1,4 @@
-const {Annotation} = require('zipkin');
+const {Annotation, InetAddress} = require('zipkin');
 const redisCommands = require('redis-commands');
 module.exports = function zipkinClient(
   tracer,
@@ -9,7 +9,7 @@ module.exports = function zipkinClient(
 ) {
   const sa = {
     serviceName: remoteServiceName,
-    host: options.host,
+    host: new InetAddress(options.host),
     port: options.port
   };
   function mkZipkinCallback(callback, id) {

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -41,7 +41,7 @@ describe('redis interceptor', () => {
             const sa = spanAnnotations[2].annotation;
             expect(sa.annotationType).to.equal('ServerAddr');
             expect(sa.serviceName).to.equal('redis');
-            expect(sa.host).to.equal(redisConnectionOptions.host);
+            expect(sa.host.addr).to.equal(redisConnectionOptions.host);
             expect(sa.port).to.equal(redisConnectionOptions.port);
 
             let lastSpanId;


### PR DESCRIPTION
raise an error
```
{
  "code": "InternalError",
  "message": "rec.annotation.host.toInt is not a function"
}
```