### PR TITLE
Use events instead of optional callback

### DIFF
--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -24,7 +24,15 @@ function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceNam
       tracer.recordAnnotation(new Annotation.ClientRecv());
     };
 
-    return request(wrappedOptions, callback).on('response', recordResponse);
+    const recordError = (error) => {
+      tracer.setId(traceId);
+      tracer.recordBinary('request.error', error.toString());
+      tracer.recordAnnotation(new Annotation.ClientRecv());
+    };
+
+    return request(wrappedOptions, callback)
+      .on('response', recordResponse)
+      .on('error', recordError);
   }));
 }
 

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -26,7 +26,7 @@ function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceNam
 
     const recordError = (error) => {
       tracer.setId(traceId);
-      tracer.recordBinary('request.error', error.toString());
+      tracer.recordBinary('error', error.toString());
       tracer.recordAnnotation(new Annotation.ClientRecv());
     };
 

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -1,33 +1,31 @@
 const {Request, Annotation} = require('zipkin');
 
 function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceName}) {
-  return request.defaults((options, callback) => {
-    tracer.scoped(() => {
-      tracer.setId(tracer.createChildId());
-      const traceId = tracer.id;
+  return request.defaults((options, callback) => tracer.scoped(() => {
+    tracer.setId(tracer.createChildId());
+    const traceId = tracer.id;
 
-      const wrappedOptions = Request.addZipkinHeaders(options, tracer.id);
-      tracer.recordServiceName(serviceName);
-      const method = wrappedOptions.method || 'GET';
-      tracer.recordRpc(method.toUpperCase());
-      tracer.recordBinary('http.url', wrappedOptions.uri || wrappedOptions.url);
-      tracer.recordAnnotation(new Annotation.ClientSend());
-      if (remoteServiceName) {
-        tracer.recordAnnotation(new Annotation.ServerAddr({
-          serviceName: remoteServiceName
-        }));
-      }
+    const wrappedOptions = Request.addZipkinHeaders(options, tracer.id);
+    const method = wrappedOptions.method || 'GET';
 
-      const wrappedCallback = (error, response, body) => {
-        tracer.setId(traceId);
-        tracer.recordBinary('http.status_code', response.statusCode.toString());
-        tracer.recordAnnotation(new Annotation.ClientRecv());
-        return callback(error, response, body);
-      };
+    tracer.recordServiceName(serviceName);
+    tracer.recordRpc(method.toUpperCase());
+    tracer.recordBinary('http.url', wrappedOptions.uri || wrappedOptions.url);
+    tracer.recordAnnotation(new Annotation.ClientSend());
+    if (remoteServiceName) {
+      tracer.recordAnnotation(new Annotation.ServerAddr({
+        serviceName: remoteServiceName
+      }));
+    }
 
-      request(wrappedOptions, wrappedCallback);
-    });
-  });
+    const recordResponse = (response) => {
+      tracer.setId(traceId);
+      tracer.recordBinary('http.status_code', response.statusCode.toString());
+      tracer.recordAnnotation(new Annotation.ClientRecv());
+    };
+
+    return request(wrappedOptions, callback).on('response', recordResponse);
+  }));
 }
 
 module.exports = wrapRequest;

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -251,7 +251,7 @@ describe('request instrumentation - integration test', () => {
 
           expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7]).to.be.undefined;
+          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
 
           done();
         });
@@ -293,8 +293,7 @@ describe('request instrumentation - integration test', () => {
 
           expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7]).to.be.undefined;
-
+          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
           done();
         });
       });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -250,6 +250,9 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[5].annotation.value).to.equal('404');
 
           expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+
+          expect(annotations[7]).to.be.undefined;
+
           done();
         });
       });
@@ -284,11 +287,14 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
           expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('request.error');
+          expect(annotations[5].annotation.key).to.equal('error');
           expect(annotations[5].annotation.value)
             .to.contain('Error: getaddrinfo ENOTFOUND bad.invalid.url bad.invalid.url:80');
 
           expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+
+          expect(annotations[7]).to.be.undefined;
+
           done();
         });
       });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -5,6 +5,9 @@ const sinon = require('sinon');
 const wrapRequest = require('../src/wrapRequest');
 
 describe('request instrumentation - integration test', () => {
+  const serviceName = 'weather-app';
+  const remoteServiceName = 'weather-api';
+
   let api;
   before(() => {
     api = express();
@@ -29,9 +32,6 @@ describe('request instrumentation - integration test', () => {
 
   it('should add headers to requests', done => {
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
-      const remoteServiceName = 'weather-api';
-
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
@@ -69,9 +69,6 @@ describe('request instrumentation - integration test', () => {
   });
   it('should support request shorthand (defaults to GET)', done => {
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
-      const remoteServiceName = 'weather-api';
-
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
@@ -109,14 +106,87 @@ describe('request instrumentation - integration test', () => {
   });
   it('should support both url and uri options', done => {
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
-      const remoteServiceName = 'weather-api';
-
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
         const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
         zipkinRequest({url}, () => {
+          const annotations = record.args.map(args => args[0]);
+          const initialTraceId = annotations[0].traceId.traceId;
+          annotations.forEach(ann => expect(ann.traceId.traceId)
+            .to.equal(initialTraceId).and
+            .to.have.lengthOf(16));
+
+          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+          expect(annotations[1].annotation.name).to.equal('GET');
+
+          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[2].annotation.key).to.equal('http.url');
+          expect(annotations[2].annotation.value).to.equal(url);
+
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
+
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          done();
+        });
+      });
+    });
+  });
+  it('should support callback as an options', done => {
+    tracer.scoped(() => {
+      const apiServer = api.listen(0, () => {
+        const apiPort = apiServer.address().port;
+        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        zipkinRequest({
+          url, callback: () => {
+            const annotations = record.args.map(args => args[0]);
+            const initialTraceId = annotations[0].traceId.traceId;
+            annotations.forEach(ann => expect(ann.traceId.traceId)
+              .to.equal(initialTraceId).and
+              .to.have.lengthOf(16));
+
+            expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+            expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+
+            expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+            expect(annotations[1].annotation.name).to.equal('GET');
+
+            expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[2].annotation.key).to.equal('http.url');
+            expect(annotations[2].annotation.value).to.equal(url);
+
+            expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+
+            expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+
+            expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[5].annotation.key).to.equal('http.status_code');
+            expect(annotations[5].annotation.value).to.equal('202');
+
+            expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+            done();
+          }
+        });
+      });
+    });
+  });
+  it('should support on response event', done => {
+    tracer.scoped(() => {
+      const apiServer = api.listen(0, () => {
+        const apiPort = apiServer.address().port;
+        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        zipkinRequest({url}).on('response', () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
           annotations.forEach(ann => expect(ann.traceId.traceId)


### PR DESCRIPTION
White space aside, the biggest change is to use `.on('response', ...)` instead of wrapping the optional callback. Some libraries (like `express-request-proxy` which use `request` internally) do not always include a callback. There is the option to listen for a `response` event. This event is always emitted by `request` when a response is returned so I think it's a better approach then the original `wrappedCallback`.