### PR TITLE
Rename ‘request.error’ to ‘error’

### DIFF
--- a/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
+++ b/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
@@ -30,7 +30,7 @@ function wrapFetch(fetch, {tracer, serviceName = 'unknown', remoteServiceName}) 
         }).catch(err => {
           tracer.scoped(() => {
             tracer.setId(traceId);
-            tracer.recordBinary('request.error', err.toString());
+            tracer.recordBinary('error', err.toString());
             tracer.recordAnnotation(new Annotation.ClientRecv());
           });
           reject(err);


### PR DESCRIPTION
This will allow the errors to be shown in the UI as well as follows the standard for error recording.