### PR TITLE
fix problem with skipping some messages in HttpLogger.js

### DIFF
--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -33,11 +33,10 @@ class HttpLogger {
           console.error('Unexpected response while sending Zipkin data, status:' +
             `${response.status}, body: ${postBody}`);
         }
-        this.queue.length = 0;
       }).catch((error) => {
         console.error('Error sending Zipkin data', error);
-        this.queue.length = 0;
       });
+      this.queue.length = 0;
     }
   }
 }


### PR DESCRIPTION
The problem: if some messages are added to queue while pushing to zipkin, they will be lost.