### PR TITLE
Extract packages to reduce dependencies for browser based environments

### DIFF
--- a/packages/zipkin-instrumentation-express/src/expressMiddleware.js
+++ b/packages/zipkin-instrumentation-express/src/expressMiddleware.js
@@ -82,7 +82,7 @@ module.exports = function expressMiddleware({tracer, serviceName = 'unknown', po
       tracer.recordRpc(req.method.toUpperCase());
       tracer.recordBinary('http.url', formatRequestUrl(req));
       tracer.recordAnnotation(new Annotation.ServerRecv());
-      tracer.recordAnnotation(new Annotation.LocalAddr({port}));
+      tracer.recordLocalAddr({port});
 
       if (id.flags !== 0 && id.flags != null) {
         tracer.recordBinary(Header.Flags, id.flags.toString());

--- a/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
+++ b/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
@@ -81,7 +81,7 @@ exports.register = (server, {tracer, serviceName = 'unknown', port = 0}, next) =
       tracer.recordRpc(request.method.toUpperCase());
       tracer.recordBinary('http.url', url.format(request.url));
       tracer.recordAnnotation(new Annotation.ServerRecv());
-      tracer.recordAnnotation(new Annotation.LocalAddr({port}));
+      tracer.recordLocalAddr({port});
 
       if (id.flags !== 0 && id.flags != null) {
         tracer.recordBinary(Header.Flags, id.flags.toString());

--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -76,7 +76,7 @@ module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', po
         pathname: req.path()
       }));
       tracer.recordAnnotation(new Annotation.ServerRecv());
-      tracer.recordAnnotation(new Annotation.LocalAddr({port}));
+      tracer.recordLocalAddr({port});
 
       if (id.flags !== 0 && id.flags != null) {
         tracer.recordBinary(Header.Flags, id.flags.toString());

--- a/packages/zipkin-local-address/README.md
+++ b/packages/zipkin-local-address/README.md
@@ -1,0 +1,13 @@
+# Zipkin-local-address
+Adds a default host functionality, works only for node and defaults back to `127.0.0.1` in the browser.
+
+## Usage:
+
+`npm install zipkin-local-address --save`
+
+```javascript
+const zipkin = require('zipkin')
+const tracer = new zipkin.Tracer({
+  localAddr: require('zipkin-local-address'),
+})
+```

--- a/packages/zipkin-local-address/package.json
+++ b/packages/zipkin-local-address/package.json
@@ -1,22 +1,20 @@
 {
-  "name": "zipkin-transport-http",
+  "name": "zipkin-local-address",
   "version": "0.7.3",
-  "description": "Transports Zipkin trace data via HTTP",
+  "description": "Adds default host functionality",
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js",
     "prepublish": "npm run build"
   },
   "author": "Openzipkin <openzipkin.alt@gmail.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
+  "dependencies": {
+    "network-address": "^1.1.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.23.0",
-    "body-parser": "^1.15.2",
-    "express": "^4.13.4",
-    "mocha": "^3.2.0",
-    "node-fetch": "^1.5.3",
     "zipkin": "^0.7.3"
   }
 }

--- a/packages/zipkin-local-address/src/index.js
+++ b/packages/zipkin-local-address/src/index.js
@@ -1,0 +1,5 @@
+const networkAddress = require('network-address');
+
+module.exports = function getLocalAddress() {
+  return networkAddress.ipv4();
+};

--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -7,11 +7,14 @@ This is a module that sends Zipkin trace data to a configurable HTTP endpoint.
 
 ```javascript
 const {Tracer, BatchRecorder} = require('zipkin');
+// you may overwrite fetch in node, otherwise it defaults to window.fetch
+const fetch = require('node-fetch'); 
 const {HttpLogger} = require('zipkin-transport-http');
 
 const recorder = new BatchRecorder({
   logger: new HttpLogger({
-    endpoint: 'http://localhost:9411/api/v1/spans'
+    endpoint: 'http://localhost:9411/api/v1/spans',
+    fetch
   })
 });
 

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -3,13 +3,11 @@ const globalFetch =
   (typeof window !== 'undefined' && window.fetch) ||
   (typeof global !== 'undefined' && global.fetch);
 
-// eslint-disable-next-line global-require
-const fetch = globalFetch || require('node-fetch');
-
 class HttpLogger {
-  constructor({endpoint, httpInterval = 1000}) {
+  constructor({endpoint, httpInterval = 1000, fetch = globalFetch}) {
     this.endpoint = endpoint;
     this.queue = [];
+    this.fetch = fetch;
 
     const timer = setInterval(() => {
       this.processQueue();
@@ -26,7 +24,7 @@ class HttpLogger {
   processQueue() {
     if (this.queue.length > 0) {
       const postBody = JSON.stringify(this.queue);
-      fetch(this.endpoint, {
+      this.fetch(this.endpoint, {
         method: 'POST',
         body: postBody,
         headers: {

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -1,4 +1,5 @@
 const {Tracer, BatchRecorder, Annotation, ExplicitContext} = require('zipkin');
+const fetch = require('node-fetch');
 const HttpLogger = require('../src/HttpLogger');
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -19,7 +20,8 @@ describe('HTTP transport - integration test', () => {
     this.server = app.listen(0, () => {
       this.port = this.server.address().port;
       const httpLogger = new HttpLogger({
-        endpoint: `http://localhost:${this.port}/api/v1/spans`
+        endpoint: `http://localhost:${this.port}/api/v1/spans`,
+        fetch
       });
 
       const ctxImpl = new ExplicitContext();

--- a/packages/zipkin/package.json
+++ b/packages/zipkin/package.json
@@ -14,7 +14,6 @@
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
     "base64-js": "^1.1.2",
-    "network-address": "^1.1.0",
     "thrift": "^0.10.0"
   },
   "devDependencies": {

--- a/packages/zipkin/src/InetAddress.js
+++ b/packages/zipkin/src/InetAddress.js
@@ -18,16 +18,4 @@ class InetAddress {
   }
 }
 
-// In non-node environments we fallback to 127.0.0.1
-InetAddress.getLocalAddress = function getLocalAddress() {
-  const isNode = typeof process === 'object' && typeof process.on === 'function';
-  if (!isNode) {
-    return new InetAddress('127.0.0.1');
-  }
-
-  // eslint-disable-next-line global-require
-  const networkAddress = require('network-address');
-  return new InetAddress(networkAddress.ipv4());
-};
-
 module.exports = InetAddress;

--- a/packages/zipkin/src/annotation.js
+++ b/packages/zipkin/src/annotation.js
@@ -48,8 +48,8 @@ ServerAddr.prototype.toString = function() {
   return `ServerAddr(serviceName="${this.serviceName}", host="${this.host}", port=${this.port})`;
 };
 
-function LocalAddr({host, port}) {
-  this.host = host || InetAddress.getLocalAddress();
+function LocalAddr({host, port}, getLocalAddress) {
+  this.host = host || new InetAddress(getLocalAddress());
   this.port = port || 0;
 }
 LocalAddr.prototype.toString = function() {

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -16,6 +16,7 @@ class Tracer {
     ctxImpl = requiredArg('ctxImpl'),
     recorder = requiredArg('recorder'),
     sampler = new Sampler(alwaysSample),
+    localAddr = () => '127.0.0.1',
     // traceID128Bit enables the generation of 128 bit traceIDs in case the tracer
     // needs to create a root span. By default regular 64 bit traceIDs are used.
     // Regardless of this setting, the library will propagate and support both
@@ -29,6 +30,7 @@ class Tracer {
     this._defaultTraceId = this.createRootId();
     this._startTimestamp = now();
     this._startTick = hrtime();
+    this._localAddr = localAddr;
   }
 
   scoped(callback) {
@@ -125,7 +127,7 @@ class Tracer {
 
   recordLocalAddr(ia) {
     this.recordAnnotation(
-      new Annotation.LocalAddr(ia)
+      new Annotation.LocalAddr(ia, this._localAddr)
     );
   }
 

--- a/packages/zipkin/test/InetAddress.test.js
+++ b/packages/zipkin/test/InetAddress.test.js
@@ -1,9 +1,5 @@
 const InetAddress = require('../src/InetAddress');
 describe('InetAddress', () => {
-  it('should get the local address', () => {
-    InetAddress.getLocalAddress();
-  });
-
   it('should convert an IP address to integer representation', () => {
     const addr = new InetAddress('80.91.37.133');
     expect(addr.toInt()).to.equal(1348150661);

--- a/packages/zipkin/test/annotation.test.js
+++ b/packages/zipkin/test/annotation.test.js
@@ -3,7 +3,7 @@ const annotation = require('../src/annotation');
 describe('Annotation types', () => {
   Object.keys(annotation).forEach(key => {
     it(`should have annotationType ${key}`, () => {
-      const ann = new annotation[key]({});
+      const ann = new annotation[key]({}, () => {});
       expect(ann.annotationType).to.equal(key);
     });
   });


### PR DESCRIPTION
Hey there,

We wanted to get zipkin-js working in a React Native environment, therefore we needed to get rid of the node dependencies. 

I hope you like the way we chose to inject the dependencies into the modules, we tried to stay as close as possible to the existing implementation.

\cc @nicolai86