### PR TITLE
Kafka 010

### DIFF
--- a/packages/zipkin-transport-kafka/README.md
+++ b/packages/zipkin-transport-kafka/README.md
@@ -23,3 +23,18 @@ const tracer = new Tracer({
   ctxImpl // this would typically be a CLSContext or ExplicitContext
 });
 ```
+
+If you do not use zookeeper to store offsets, use `clientOpts.kafkaHost` instead of `clientOpts.connectionString`.
+
+```js
+const {BatchRecorder} = require('zipkin');
+const {KafkaLogger} = require('zipkin-transport-kafka');
+
+const kafkaRecorder = new BatchRecorder({
+  logger: new KafkaLogger({
+    clientOpts: {
+      kafkaHost: 'localhost:2181'
+    }
+  })
+});
+```

--- a/packages/zipkin-transport-kafka/package.json
+++ b/packages/zipkin-transport-kafka/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "kafka-node": "^1.0.0"
+    "kafka-node": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -14,9 +14,13 @@ module.exports = class KafkaLogger {
     const producerOpts = Object.assign({}, producerDefaults, options.producerOpts || {});
     this.producerPromise = new Promise((resolve, reject) => {
       this.topic = options.topic || 'zipkin';
-      this.client = new kafka.Client(
-        clientOpts.connectionString, clientOpts.clientId, clientOpts.zkOpts
-      );
+      if (clientOpts.connectionString) {
+        this.client = new kafka.Client(
+          clientOpts.connectionString, clientOpts.clientId, clientOpts.zkOpts
+        );
+      } else {
+        this.client = new kafka.KafkaClient(clientOpts);
+      }
       const producer = new kafka.HighLevelProducer(this.client, producerOpts);
       producer.on('ready', () => resolve(producer));
       producer.on('error', reject);

--- a/packages/zipkin-transport-kafka/test/integrationTest.js
+++ b/packages/zipkin-transport-kafka/test/integrationTest.js
@@ -112,4 +112,104 @@ describe('Kafka transport - integration test', () => {
       done(err);
     });
   });
+
+  it('should send trace data to Kafka without zookeeper', function(done) {
+    this.slow(10 * 1000);
+    this.timeout(60 * 1000);
+
+    makeKafkaServer().then(kafkaServer => {
+      const producerClient = new kafka.Client(
+        `localhost:${kafkaServer.zookeeperPort}`,
+        'zipkin-integration-test-producer'
+      );
+      const producer = new kafka.Producer(producerClient);
+      let client;
+      let kafkaLogger;
+      function finish(arg) {
+        /* eslint-disable arrow-body-style */
+
+        const closeProducerClient = () => new Promise(resolve => producerClient.close(resolve));
+        const closeClient = () => {
+          return client ?
+            new Promise(resolve => client.close(resolve))
+            : Promise.resolve();
+        };
+
+        const closeKafkaLogger = () => {
+          return kafkaLogger ?
+            kafkaLogger.close() :
+            Promise.resolve();
+        };
+
+        closeKafkaLogger()
+          .then(closeProducerClient())
+          .then(closeClient())
+          .then(() => kafkaServer.close()
+            .then(() => done(arg)));
+      }
+
+      return new Promise(resolve => {
+        console.log('creating topic...');
+        producer.on('ready', () => {
+          producer.createTopics(['zipkin'], true, err => {
+            if (err) {
+              finish(err);
+            } else {
+              console.log('topic was created');
+              resolve();
+            }
+          });
+        });
+      }).then(() => waitPromise(1000)).then(() => {
+        client = new kafka.Client(
+          `localhost:${kafkaServer.zookeeperPort}`,
+          'zipkin-integration-test-consumer'
+        );
+        const consumer = new kafka.HighLevelConsumer(
+          client,
+          [{topic: 'zipkin'}],
+          {
+            groupId: 'zipkin'
+          }
+        );
+        consumer.on('message', message => {
+          console.log('Received Zipkin data from Kafka');
+          expect(message.topic).to.equal('zipkin');
+          expect(message.value).to.contain('http://example.com');
+          consumer.close(true, finish);
+        });
+
+        client.on('error', err => {
+          console.log('client error', err);
+          finish(err);
+        });
+        consumer.on('error', err => {
+          console.log('consumer error', err);
+          consumer.close(true, () => finish(err));
+        });
+
+        kafkaLogger = new KafkaLogger({
+          clientOpts: {
+            kafkaHost: `localhost:${kafkaServer.kafkaPort}`
+          }
+        });
+
+        const ctxImpl = new ExplicitContext();
+        const recorder = new BatchRecorder({logger: kafkaLogger});
+        const tracer = new Tracer({recorder, ctxImpl});
+
+        ctxImpl.scoped(() => {
+          tracer.recordAnnotation(new Annotation.ServerRecv());
+          tracer.recordServiceName('my-service');
+          tracer.recordRpc('GET');
+          tracer.recordBinary('http.url', 'http://example.com');
+          tracer.recordBinary('http.response_code', '200');
+          tracer.recordAnnotation(new Annotation.ServerSend());
+        });
+      });
+    }).catch(err => {
+      console.error('Big err', err);
+      done(err);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #118 

- First commit upgrades to `kafka-node@2`. The only breaking change is for consumers, and since we just produce here, that doesn't matter
  - https://github.com/SOHU-Co/kafka-node/blob/04a248ae1ffb4d6700823f77a80f84ed02948ba9/CHANGELOG.md#2017-07-08-version-200
- Second commit adds a `useZookeeper` option which defaults to `true` to avoid a breaking change
  - If set to `false` we create a new `KafkaClient` instead of `Client`, which does not use zookeeper
  - https://github.com/SOHU-Co/kafka-node/blob/04a248ae1ffb4d6700823f77a80f84ed02948ba9/README.md#kafkaclient