### PR TITLE
Fix: Binary annotation cannot be array (must be string)

### DIFF
--- a/packages/zipkin-instrumentation-redis/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-redis/src/zipkinClient.js
@@ -57,7 +57,7 @@ module.exports = function zipkinClient(
           tracer.scoped(() => {
             id = tracer.createChildId();
             tracer.setId(id);
-            tracer.recordBinary('commands', args[0]);
+            tracer.recordBinary('commands', JSON.stringify(args[0]));
           });
           wrap(multiInstance, id);
           return multiInstance;

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -91,7 +91,7 @@ describe('redis interceptor', () => {
         const firstAnn = annotations[0];
         expect(annotations).to.have.length(11);
         expect(annotations[5].annotation.key).to.equal('commands');
-        expect(annotations[5].annotation.value).to.deep.equal([['get', 'ping']]);
+        expect(annotations[5].annotation.value).to.deep.equal('[["get","ping"]]');
         expect(annotations[6].annotation.name).to.equal('exec');
 
         // we expect two spans, run annotations tests for each


### PR DESCRIPTION
In #116 I made an unfortunate error and passed an array to recordBinary.. This will create an erroneous trace, which cannot be sent to zipkin.