### PR TITLE
context backed by cls-hooked (for async/await support)

### DIFF
--- a/packages/zipkin-context-cls-hooked/README.md
+++ b/packages/zipkin-context-cls-hooked/README.md
@@ -1,0 +1,26 @@
+# zipkin-context-cls-hooked
+
+This module implements a context API on top of [Continuation-Local Storage ( Hooked )](https://github.com/jeff-lewis/cls-hooked).
+
+The primary objective of CLS is to implement a *transparent* context API, that is, you don't need to pass around a `ctx`
+variable everywhere in your application code.
+
+CLS-hooked is a fork of CLS to support **async/await** notation in Node v8 and higher.
+
+If using Node v7 or lower please make sure to understand the limitations of [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked)
+and consider using [zipkin-context-cls](https://github.com/openzipkin/zipkin-js/tree/master/packages/zipkin-context-cls) instead.
+
+## Usage:
+
+```javascript
+const CLSHookedContext = require('zipkin-context-cls-hooked');
+const tracer = new Tracer({
+  ctxImpl: new CLSHookedContext('zipkin'),
+  recorder // typically Kafka or Scribe
+});
+```
+
+## A note on CLS context vs. explicit context
+
+There are known issues and limitations with CLS, so some people might prefer to use `ExplicitContext` instead;
+the drawback then is that you have to pass around a context object manually.

--- a/packages/zipkin-context-cls-hooked/package.json
+++ b/packages/zipkin-context-cls-hooked/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "zipkin-context-cls-hooked",
+  "version": "0.1.0",
+  "description": "A Context API implementation that uses cls-hooked under the hood",
+  "main": "lib/CLSHookedContext.js",
+  "scripts": {
+    "build": "babel src -d lib",
+    "test": "mocha --require ../../test/helper.js",
+    "prepublish": "npm run build"
+  },
+  "author": "OpenZipkin <openzipkin.alt@gmail.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "dependencies": {
+    "cls-hooked": "^4.2.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "mocha": "^3.2.0"
+  }
+}

--- a/packages/zipkin-context-cls-hooked/src/CLSHookedContext.js
+++ b/packages/zipkin-context-cls-hooked/src/CLSHookedContext.js
@@ -1,0 +1,37 @@
+const {createNamespace, getNamespace} = require('cls-hooked');
+
+module.exports = class CLSHookedContext {
+  constructor(namespace = 'zipkin') {
+    this._session = getNamespace(namespace) || createNamespace(namespace);
+    const defaultContext = this._session.createContext();
+    this._session.enter(defaultContext);
+  }
+
+  setContext(ctx) {
+    this._session.set('zipkin', ctx);
+  }
+
+  getContext() {
+    const currentCtx = this._session.get('zipkin');
+    if (currentCtx != null) {
+      return currentCtx;
+    } else {
+      return null; // explicitly return null (not undefined)
+    }
+  }
+
+  scoped(callable) {
+    let result;
+    this._session.run(() => {
+      result = callable();
+    });
+    return result;
+  }
+
+  letContext(ctx, callable) {
+    return this.scoped(() => {
+      this.setContext(ctx);
+      return callable();
+    });
+  }
+};

--- a/packages/zipkin-context-cls-hooked/test/.eslintrc
+++ b/packages/zipkin-context-cls-hooked/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true
+  }
+}

--- a/packages/zipkin-context-cls-hooked/test/CLSContext.test.js
+++ b/packages/zipkin-context-cls-hooked/test/CLSContext.test.js
@@ -1,0 +1,70 @@
+const CLSContext = require('../');
+describe('CLSContext', () => {
+  it('should start with context null', () => {
+    const ctx = new CLSContext();
+    expect(ctx.getContext()).to.equal(null);
+  });
+
+  it('should set an inner context', () => {
+    const ctx = new CLSContext();
+    ctx.letContext('foo', () => {
+      expect(ctx.getContext()).to.equal('foo');
+    });
+  });
+
+  it('should set an inner context with setContext', () => {
+    const ctx = new CLSContext();
+    ctx.scoped(() => {
+      ctx.setContext('bla');
+      expect(ctx.getContext()).to.equal('bla');
+    });
+    expect(ctx.getContext()).to.equal(null);
+  });
+
+  it('should return the inner value', () => {
+    const ctx = new CLSContext();
+    const returnValue = ctx.letContext('foo', () => 123);
+    expect(returnValue).to.equal(123);
+  });
+
+  it('should be reset after the callback', () => {
+    const ctx = new CLSContext();
+    ctx.letContext('foo', () => {
+      // do nothing
+    });
+    expect(ctx.getContext()).to.equal(null);
+  });
+
+  it('support nested contexts', () => {
+    const ctx = new CLSContext();
+    const finalReturnValue = ctx.letContext('foo', () => {
+      expect(ctx.getContext()).to.equal('foo');
+      const innerReturnValue = ctx.letContext('bar', () => {
+        expect(ctx.getContext()).to.equal('bar');
+        return 1;
+      });
+      expect(ctx.getContext()).to.equal('foo');
+      return innerReturnValue + 2;
+    });
+    expect(ctx.getContext()).to.equal(null);
+    expect(finalReturnValue).to.equal(3);
+  });
+
+  it('supports CLS contexts (setTimeout etc)', done => {
+    const ctx = new CLSContext();
+    function callback() {
+      expect(ctx.getContext()).to.equal('foo');
+      done();
+    }
+    ctx.letContext('foo', () => {
+      setTimeout(callback, 10);
+    });
+  });
+
+  it('supports async/await contexts', async () => {
+    const ctx = new CLSContext();
+    return await (async () => {
+      expect(ctx.getContext()).to.equal('foo');
+    })();
+  });
+});

--- a/packages/zipkin-context-cls/README.md
+++ b/packages/zipkin-context-cls/README.md
@@ -4,6 +4,9 @@ This module implements a context API on top of [CLS/continuation-local-storage](
 The primary objective of CLS is to implement a *transparent* context API, that is, you don't need to pass around a `ctx`
 variable everywhere in your application code.
 
+This library does not preserve context when **async/await** is used. If you need that functionality please
+use [zipkin-context-cls-hooked](https://github.com/openzipkin/zipkin-js/tree/master/packages/zipkin-context-cls-hooked) instead.
+
 ## Usage:
 
 ```javascript


### PR DESCRIPTION
**zipkin-context-cls** does not support the new (> node v8) [async/await notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function). This pull request addresses that.

Q: Why I haven't replaced **zipkin-context-cls** instead?
A: This library is backed by **cls-hooked** library which as I understand behaves differently for node < v8. I decided to be conservative and give the user (developer) a choice.

Fixes: #124 