### PR TITLE
Cleans up glitches, notably re-enabling 'unknown' service names

### DIFF
--- a/packages/zipkin-encoder-thrift/src/index.js
+++ b/packages/zipkin-encoder-thrift/src/index.js
@@ -3,7 +3,7 @@ const thriftTypes = require('./gen-nodejs/zipkinCore_types');
 const {TBufferedTransport, TBinaryProtocol} = require('thrift');
 
 function toThriftEndpoint(endpoint) {
-  if (endpoint === undefined || endpoint.isUnknown()) {
+  if (endpoint === undefined) {
     return undefined;
   }
   const res = new thriftTypes.Endpoint({

--- a/packages/zipkin-encoder-thrift/test/index.test.js
+++ b/packages/zipkin-encoder-thrift/test/index.test.js
@@ -116,7 +116,7 @@ describe('Thrift v1 Formatting', () => {
     span.putTag('warning', 'The cake is a lie');
 
     const expectedHost = new thriftTypes.Endpoint({
-      service_name: 'PortalService',
+      service_name: 'portalservice',
       ipv4: 171520595,
       port: 8080
     });
@@ -124,7 +124,7 @@ describe('Thrift v1 Formatting', () => {
     expected.trace_id = 'a';
     expected.parent_id = 'b';
     expected.id = 'c';
-    expected.name = 'GET';
+    expected.name = 'get';
     expected.annotations = [
       new thriftTypes.Annotation({
         timestamp: 1,
@@ -202,7 +202,7 @@ describe('Thrift v1 Formatting', () => {
     const expected = new thriftTypes.Span();
     expected.trace_id = '000000000000162e';
     expected.id = '000000000000162e';
-    expected.name = 'GET';
+    expected.name = 'get';
     expected.binary_annotations = [
       new thriftTypes.BinaryAnnotation({
         key: 'sa',
@@ -231,7 +231,7 @@ describe('Thrift v1 Formatting', () => {
     const expected = new thriftTypes.Span();
     expected.trace_id = '000000000000162e';
     expected.id = '000000000000162e';
-    expected.name = 'GET';
+    expected.name = 'get';
     expected.binary_annotations = [
       new thriftTypes.BinaryAnnotation({
         key: 'http.path',

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -14,7 +14,7 @@ describe('HTTP transport - integration test', () => {
       res.status(202).json({});
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
-      expect(traceData[0].name).to.equal('GET');
+      expect(traceData[0].name).to.equal('get');
       expect(traceData[0].binaryAnnotations.length).to.equal(2);
       expect(traceData[0].annotations.length).to.equal(2);
       this.server.close(done);
@@ -47,7 +47,7 @@ describe('HTTP transport - integration test', () => {
       res.status(202).json({});
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
-      expect(traceData[0].name).to.equal('GET');
+      expect(traceData[0].name).to.equal('get');
       expect(traceData[0].kind).to.equal('SERVER');
       expect(traceData[0].tags['http.url']).to.equal('http://example.com');
       expect(traceData[0].tags['http.response_code']).to.equal('200');

--- a/packages/zipkin/src/jsonEncoder.js
+++ b/packages/zipkin/src/jsonEncoder.js
@@ -1,5 +1,5 @@
 function toV1Endpoint(endpoint) {
-  if (endpoint === undefined || endpoint.isUnknown()) {
+  if (endpoint === undefined) {
     return undefined;
   }
   const res = {

--- a/packages/zipkin/src/model.js
+++ b/packages/zipkin/src/model.js
@@ -1,11 +1,21 @@
 function Endpoint({serviceName, ipv4, port}) {
-  this.serviceName = serviceName;
-  this.ipv4 = ipv4;
-  this.port = port;
+  this.setServiceName(serviceName);
+  this.setIpv4(ipv4);
+  this.setPort(port);
 }
-Endpoint.prototype.isUnknown = function isUnknown() {
-  return (this.serviceName === undefined || this.serviceName === 'unknown') &&
-          this.ipv4 === undefined && this.port === undefined;
+Endpoint.prototype.setServiceName = function setServiceName(serviceName) {
+  // In zipkin, names are lowercase. This eagerly converts to alert users early.
+  this.serviceName = serviceName ? serviceName.toLocaleLowerCase() : undefined;
+};
+Endpoint.prototype.setIpv4 = function setIpv4(ipv4) {
+  this.ipv4 = ipv4;
+};
+Endpoint.prototype.setPort = function setPort(port) {
+  this.port = port || undefined;
+};
+Endpoint.prototype.isEmpty = function isEmpty() {
+  return this.serviceName === undefined &&
+         this.ipv4 === undefined && this.port === undefined;
 };
 
 function Annotation(timestamp, value) {
@@ -35,7 +45,8 @@ function Span(traceId) {
 }
 
 Span.prototype.setName = function setName(name) {
-  this.name = name;
+  // In zipkin, names are lowercase. This eagerly converts to alert users early.
+  this.name = name ? name.toLocaleLowerCase() : undefined;
 };
 Span.prototype.setKind = function setKind(kind) {
   this.kind = kind;
@@ -50,14 +61,18 @@ Span.prototype.setDuration = function setDuration(duration) {
   }
 };
 Span.prototype.setLocalEndpoint = function setLocalEndpoint(ep) {
-  if (ep && !ep.isUnknown()) {
+  if (ep && !ep.isEmpty()) {
     this.localEndpoint = ep;
   } else {
     this.localEndpoint = undefined;
   }
 };
 Span.prototype.setRemoteEndpoint = function setRemoteEndpoint(ep) {
-  this.remoteEndpoint = ep;
+  if (ep && !ep.isEmpty()) {
+    this.remoteEndpoint = ep;
+  } else {
+    this.remoteEndpoint = undefined;
+  }
 };
 Span.prototype.addAnnotation = function addAnnotation(timestamp, value) {
   this.annotations.push(new Annotation(timestamp, value));

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -44,9 +44,9 @@ describe('Batch Recorder', () => {
       expect(loggedSpan.traceId).to.equal('a');
       expect(loggedSpan.parentId).to.equal('a');
       expect(loggedSpan.id).to.equal('c');
-      expect(loggedSpan.name).to.eql('buySmoothie');
+      expect(loggedSpan.name).to.eql('buysmoothie');
       expect(loggedSpan.kind).to.equal('SERVER');
-      expect(loggedSpan.localEndpoint.serviceName).to.equal('SmoothieStore');
+      expect(loggedSpan.localEndpoint.serviceName).to.equal('smoothiestore');
       expect(loggedSpan.localEndpoint.ipv4).to.equal('127.0.0.1');
       expect(loggedSpan.localEndpoint.port).to.equal(7070);
       expect(loggedSpan.tags.taste).to.equal('banana');
@@ -81,7 +81,7 @@ describe('Batch Recorder', () => {
 
       const loggedSpan = logSpan.getCall(0).args[0];
 
-      expect(loggedSpan.name).to.eql('rentSmoothie');
+      expect(loggedSpan.name).to.eql('rentsmoothie');
     });
   });
 
@@ -142,7 +142,7 @@ describe('Batch Recorder', () => {
     });
   });
 
-  it('should record minimum duration of 1 microsecond', () => {
+  it('should record duration in microseconds', () => {
     const clock = lolex.install(12345678);
     const logSpan = sinon.spy();
 
@@ -159,13 +159,13 @@ describe('Batch Recorder', () => {
       }));
       trace.recordRpc('GET');
       trace.recordAnnotation(new Annotation.ClientSend());
-      clock.tick(0.000123);
+      clock.tick(0.123456);
       trace.recordAnnotation(new Annotation.ClientRecv());
 
       const loggedSpan = logSpan.getCall(0).args[0];
 
       expect(loggedSpan.timestamp).to.equal(12345678000);
-      expect(loggedSpan.duration).to.equal(1); // rounds up!
+      expect(loggedSpan.duration).to.equal(123);
 
       clock.uninstall();
     });

--- a/packages/zipkin/test/jsonEncoder.JSON_V1.test.js
+++ b/packages/zipkin/test/jsonEncoder.JSON_V1.test.js
@@ -72,13 +72,13 @@ describe('JSON v1 Formatting', () => {
 
     const expected = {
       traceId: 'a',
-      name: 'GET',
+      name: 'get',
       id: 'c',
       parentId: 'b',
       annotations: [
         {
           endpoint: {
-            serviceName: 'PortalService',
+            serviceName: 'portalservice',
             ipv4: '10.57.50.83',
             port: 8080
           },
@@ -87,7 +87,7 @@ describe('JSON v1 Formatting', () => {
         },
         {
           endpoint: {
-            serviceName: 'PortalService',
+            serviceName: 'portalservice',
             ipv4: '10.57.50.83',
             port: 8080,
           },
@@ -100,7 +100,7 @@ describe('JSON v1 Formatting', () => {
           key: 'warning',
           value: 'The cake is a lie',
           endpoint: {
-            serviceName: 'PortalService',
+            serviceName: 'portalservice',
             ipv4: '10.57.50.83',
             port: 8080
           }

--- a/packages/zipkin/test/jsonEncoder.JSON_V2.test.js
+++ b/packages/zipkin/test/jsonEncoder.JSON_V2.test.js
@@ -70,14 +70,14 @@ describe('JSON v2 Formatting', () => {
 
     const expected = {
       traceId: 'a',
-      name: 'GET',
+      name: 'get',
       id: 'c',
       parentId: 'b',
       kind: 'SERVER',
       timestamp: 1,
       duration: 1,
       localEndpoint: {
-        serviceName: 'PortalService',
+        serviceName: 'portalservice',
         ipv4: '10.57.50.83',
         port: 8080
       },

--- a/packages/zipkin/test/model.test.js
+++ b/packages/zipkin/test/model.test.js
@@ -1,0 +1,59 @@
+const TraceId = require('../src/tracer/TraceId');
+const {Span, Endpoint} = require('../src/model');
+const {Some} = require('../src/option');
+
+describe('Endpoint setters', () => {
+  // Zipkin does this, so doing so early alerts users
+  it('should lowercase serviceName', () => {
+    const endpoint = new Endpoint({
+      serviceName: 'Unknown'
+    });
+    expect(endpoint.serviceName).to.equal('unknown');
+  });
+});
+
+describe('Span setters', () => {
+  // Zipkin does this, so doing so early alerts users
+  it('should lowercase name', () => {
+    const span = new Span(new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b',
+    }));
+    span.setName('StarWars');
+    expect(span.name).to.equal('starwars');
+  });
+
+  // otherwise people can't find their spans
+  it('span.setLocalEndpoint() should accept unknown serviceName', () => {
+    const span = new Span(new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b',
+    }));
+    span.setLocalEndpoint(new Endpoint({
+      serviceName: 'unknown'
+    }));
+    expect(span.localEndpoint.serviceName).to.equal('unknown');
+  });
+
+  it('should not set empty endpoints', () => {
+    const span = new Span(new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b',
+    }));
+    span.setLocalEndpoint(new Endpoint({}));
+    span.setRemoteEndpoint(new Endpoint({}));
+
+    expect(span.localEndpoint).to.equal(undefined);
+    expect(span.remoteEndpoint).to.equal(undefined);
+  });
+
+  it('should set minimum duration of 1 microsecond', () => {
+    const span = new Span(new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b',
+    }));
+    span.setDuration(0.77);
+
+    expect(span.duration).to.equal(1);
+  });
+});


### PR DESCRIPTION
Integrating react native, I noticed we weren't recording spans against
the default service name set by instrumentation (always 'unknown').

This also fixes some other glitches noticed when looking carefully at
the data as well the lint problem ignored formerly.