### PR TITLE
Add support for setting custom HTTP headers in HTTP transport

### DIFF
--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -16,7 +16,9 @@ const {HttpLogger} = require('zipkin-transport-http');
 const recorder = new BatchRecorder({
   logger: new HttpLogger({
     endpoint: 'http://localhost:9411/api/v2/spans',
-    jsonEncoder: JSON_V2
+    jsonEncoder: JSON_V2, // optional, defaults to JSON_V1
+    httpInterval: 1000, // how often to sync spans. optional, defaults to 1000
+    headers: {'Authorization': 'secret'} // optional custom HTTP headers
   })
 });
 
@@ -25,3 +27,4 @@ const tracer = new Tracer({
   ctxImpl // this would typically be a CLSContext or ExplicitContext
 });
 ```
+

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -17,7 +17,6 @@ class HttpLogger {
     this.jsonEncoder = jsonEncoder;
 
     this.headers = Object.assign({
-      Accept: 'application/json',
       'Content-Type': 'application/json'
     }, headers);
 

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -11,10 +11,15 @@ const {
 } = require('zipkin');
 
 class HttpLogger {
-  constructor({endpoint, httpInterval = 1000, jsonEncoder = JSON_V1}) {
+  constructor({endpoint, headers = {}, httpInterval = 1000, jsonEncoder = JSON_V1}) {
     this.endpoint = endpoint;
     this.queue = [];
     this.jsonEncoder = jsonEncoder;
+
+    this.headers = Object.assign({
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }, headers);
 
     const timer = setInterval(() => {
       this.processQueue();
@@ -34,10 +39,7 @@ class HttpLogger {
       fetch(this.endpoint, {
         method: 'POST',
         body: postBody,
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json'
-        }
+        headers: this.headers,
       }).then((response) => {
         if (response.status !== 202) {
           console.error('Unexpected response while sending Zipkin data, status:' +

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -12,7 +12,6 @@ describe('HTTP transport - integration test', () => {
     app.use(bodyParser.json());
     app.post('/api/v1/spans', (req, res) => {
       res.status(202).json({});
-      expect(req.headers.accept).to.equal('application/json');
       expect(req.headers['content-type']).to.equal('application/json');
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
@@ -47,7 +46,6 @@ describe('HTTP transport - integration test', () => {
     app.use(bodyParser.json());
     app.post('/api/v1/spans', (req, res) => {
       res.status(202).json({});
-      expect(req.headers.accept).to.equal('application/json');
       expect(req.headers['content-type']).to.equal('application/json');
       expect(req.headers.authorization).to.equal('Token');
       const traceData = req.body;

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -12,6 +12,8 @@ describe('HTTP transport - integration test', () => {
     app.use(bodyParser.json());
     app.post('/api/v1/spans', (req, res) => {
       res.status(202).json({});
+      expect(req.headers.accept).to.equal('application/json');
+      expect(req.headers['content-type']).to.equal('application/json');
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
       expect(traceData[0].name).to.equal('get');
@@ -45,6 +47,9 @@ describe('HTTP transport - integration test', () => {
     app.use(bodyParser.json());
     app.post('/api/v1/spans', (req, res) => {
       res.status(202).json({});
+      expect(req.headers.accept).to.equal('application/json');
+      expect(req.headers['content-type']).to.equal('application/json');
+      expect(req.headers.authorization).to.equal('Token');
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
       expect(traceData[0].name).to.equal('get');
@@ -57,6 +62,7 @@ describe('HTTP transport - integration test', () => {
       this.port = this.server.address().port;
       const httpLogger = new HttpLogger({
         endpoint: `http://localhost:${this.port}/api/v1/spans`,
+        headers: {Authorization: 'Token'},
         jsonEncoder: JSON_V2
       });
 


### PR DESCRIPTION
This is needed because our Zipkin server is protected by tokens that must be sent as HTTP headers.