### PR TITLE
Centralizes assignment of local service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,40 @@ how tracing services looks.
 
 `npm install zipkin --save`
 
+## Basic Setup:
+
+```javascript
+const {
+  Tracer,
+  BatchRecorder,
+  jsonEncoder: {JSON_V2}
+} = require('zipkin');
+const CLSContext = require('zipkin-context-cls');
+const {HttpLogger} = require('zipkin-transport-http');
+
+// Setup the tracer to use http and implicit trace context
+const tracer = new Tracer({
+  ctxImpl: new CLSContext('zipkin'),
+  recorder: new BatchRecorder({
+    logger: new HttpLogger({
+      endpoint: 'http://localhost:9411/api/v2/spans',
+      jsonEncoder: JSON_V2
+    })
+  }),
+  localServiceName: 'service-a' // name of this application
+});
+
+// now use tracer to construct instrumentation! For example, fetch
+const wrapFetch = require('zipkin-instrumentation-fetch');
+
+const remoteServiceName = 'youtube';
+const zipkinFetch = wrapFetch(fetch, {tracer, remoteServiceName});
+```
 
 ## Instrumentations
 
 Various Node.js libraries have been instrumented with Zipkin support.
-Every instrumentation has an npm package called zipkin-instrumentation-*.
+Every instrumentation has an npm package called `zipkin-instrumentation-*`.
 
 At the time of writing, zipkin-js instruments these libraries:
 
@@ -34,7 +63,7 @@ Every module has a README.md file that describes how to use it.
 
 ## Transports
 
-You can choose between multiple transports; they are npm packages called zipkin-transport-*.
+You can choose between multiple transports; they are npm packages called `zipkin-transport-*`.
 
 Currently, the following transports are available:
 

--- a/packages/zipkin-context-cls/README.md
+++ b/packages/zipkin-context-cls/README.md
@@ -10,7 +10,8 @@ variable everywhere in your application code.
 const CLSContext = require('zipkin-context-cls');
 const tracer = new Tracer({
   ctxImpl: new CLSContext('zipkin'),
-  recorder // typically Kafka or Scribe
+  recorder, // typically Kafka or Scribe
+  localServiceName: 'service-a' // name of this application
 });
 ```
 

--- a/packages/zipkin-instrumentation-cujojs-rest/README.md
+++ b/packages/zipkin-instrumentation-cujojs-rest/README.md
@@ -9,10 +9,11 @@ const {Tracer} = require('zipkin');
 const rest = require('rest');
 const {restInterceptor} = require('zipkin-instrumentation-cujojs-rest');
 
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
-const nameOfRemoteService = 'youtube';
-const client = rest.wrap(restInterceptor, {tracer, remoteServiceName: nameOfRemoteService});
+const remoteServiceName = 'youtube';
+const client = rest.wrap(restInterceptor, {tracer, remoteServiceName});
 
 // Your application code here
 client('http://www.youtube.com/').then(success => {

--- a/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
@@ -15,7 +15,7 @@ function getRequestMethod(req) {
   return method;
 }
 
-function request(req, {tracer, serviceName = 'unknown', remoteServiceName}) {
+function request(req, {tracer, serviceName, remoteServiceName}) {
   this.instrumentation = new Instrumentation.HttpClient({tracer, serviceName, remoteServiceName});
   return tracer.scoped(() => {
     const reqWithHeaders =

--- a/packages/zipkin-instrumentation-express/README.md
+++ b/packages/zipkin-instrumentation-express/README.md
@@ -11,16 +11,13 @@ const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddle
 
 const ctxImpl = new ExplicitContext();
 const recorder = new ConsoleRecorder();
-
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const app = express();
 
 // Add the Zipkin middleware
-app.use(zipkinMiddleware({
-  tracer,
-  serviceName: 'service-a' // name of this application
-}));
+app.use(zipkinMiddleware({tracer}));
 ```
 
 ## Express HTTP Proxy

--- a/packages/zipkin-instrumentation-express/index.d.ts
+++ b/packages/zipkin-instrumentation-express/index.d.ts
@@ -13,10 +13,10 @@ import {Handler} from "express"
  * go to the correct spans
  */
 export declare function expressMiddleware(
-  options: {tracer: Tracer, serviceName?: string, port?: number}
+  options: {tracer: Tracer, port?: number}
 ): Handler;
 
 export declare function wrapExpressHttpProxy(
   proxy: (host: string, options?: any) => Handler,
-  options: {tracer: Tracer, serviceName?: string, remoteServiceName?: string}
+  options: {tracer: Tracer, remoteServiceName?: string}
 ): (host: string, options?: any) => Handler

--- a/packages/zipkin-instrumentation-express/src/expressMiddleware.js
+++ b/packages/zipkin-instrumentation-express/src/expressMiddleware.js
@@ -14,7 +14,7 @@ function formatRequestUrl(req) {
   });
 }
 
-module.exports = function expressMiddleware({tracer, serviceName = 'unknown', port = 0}) {
+module.exports = function expressMiddleware({tracer, serviceName, port = 0}) {
   const instrumentation = new Instrumentation.HttpServer({tracer, serviceName, port});
   return function zipkinExpressMiddleware(req, res, next) {
     tracer.scoped(() => {

--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -57,7 +57,7 @@ class ExpressHttpProxyInstrumentation {
   }
 }
 
-function wrapProxy(proxy, {tracer, serviceName = 'unknown', remoteServiceName}) {
+function wrapProxy(proxy, {tracer, serviceName, remoteServiceName}) {
   return function zipkinProxy(host, options = {}) {
     function wrapDecorateRequest(instrumentation, originalDecorateRequest) {
       return (proxyReq, originalReq) => {

--- a/packages/zipkin-instrumentation-fetch/README.md
+++ b/packages/zipkin-instrumentation-fetch/README.md
@@ -10,10 +10,11 @@ or [node-fetch](https://www.npmjs.com/package/node-fetch) on Node.js.
 const {Tracer} = require('zipkin');
 const wrapFetch = require('zipkin-instrumentation-fetch');
 
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
-const nameOfRemoteService = 'youtube';
-const zipkinFetch = wrapFetch(fetch, {tracer, remoteServiceName: nameOfRemoteService});
+const remoteServiceName = 'youtube';
+const zipkinFetch = wrapFetch(fetch, {tracer, remoteServiceName});
 
 // Your application code here
 zipkinFetch('http://www.youtube.com/').then(res => res.json()).then(data => ...);

--- a/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
+++ b/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
@@ -2,7 +2,7 @@ const {
   Instrumentation
 } = require('zipkin');
 
-function wrapFetch(fetch, {tracer, serviceName = 'unknown', remoteServiceName}) {
+function wrapFetch(fetch, {tracer, serviceName, remoteServiceName}) {
   const instrumentation = new Instrumentation.HttpClient({tracer, serviceName, remoteServiceName});
   return function zipkinfetch(url, opts = {}) {
     return new Promise((resolve, reject) => {

--- a/packages/zipkin-instrumentation-hapi/README.md
+++ b/packages/zipkin-instrumentation-hapi/README.md
@@ -12,16 +12,14 @@ const zipkinMiddleware = require('zipkin-instrumentation-hapi').hapiMiddleware;
 const ctxImpl = new ExplicitContext();
 const recorder = new ConsoleRecorder();
 
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const server = new Hapi.Server();
 
 // Add the Zipkin middleware
 server.register({
   register: zipkinMiddleware,
-  options: {
-    tracer,
-    serviceName: 'service-a' // name of this application
-  }
+  options: {tracer}
 });
 ```

--- a/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
+++ b/packages/zipkin-instrumentation-hapi/src/hapiMiddleware.js
@@ -14,7 +14,7 @@ function headerOption(headers, header) {
   }
 }
 
-exports.register = (server, {tracer, serviceName = 'unknown', port = 0}, next) => {
+exports.register = (server, {tracer, serviceName, port = 0}, next) => {
   const instrumentation = new Instrumentation.HttpServer({tracer, serviceName, port});
   if (tracer == null) {
     next(new Error('No tracer specified'));

--- a/packages/zipkin-instrumentation-memcached/README.md
+++ b/packages/zipkin-instrumentation-memcached/README.md
@@ -9,7 +9,8 @@ const {Tracer} = require('zipkin');
 const Memcached = require('memcached');
 const zipkinClient = require('zipkin-instrumentation-memcached');
 
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const connectionString = ''localhost:11211'';
 const options = {timeout: 1000};

--- a/packages/zipkin-instrumentation-memcached/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-memcached/src/zipkinClient.js
@@ -3,7 +3,7 @@ const {Annotation} = require('zipkin');
 module.exports = function zipkinClient(
   tracer,
   Memcached,
-  serviceName = 'unknown',
+  serviceName = tracer.localEndpoint.serviceName,
   remoteServiceName = 'memcached'
 ) {
   function mkZipkinCallback(callback, id) {

--- a/packages/zipkin-instrumentation-postgres/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-postgres/src/zipkinClient.js
@@ -3,7 +3,7 @@ const {Annotation, InetAddress} = require('zipkin');
 module.exports = function zipkinClient(
   tracer,
   Postgres,
-  serviceName = 'unknown',
+  serviceName = tracer.localEndpoint.serviceName,
   remoteServiceName = 'postgres'
 ) {
   function annotateSuccess(id) {

--- a/packages/zipkin-instrumentation-redis/README.md
+++ b/packages/zipkin-instrumentation-redis/README.md
@@ -8,7 +8,8 @@ This library will wrap the [redis client](https://www.npmjs.com/package/redis).
 const {Tracer} = require('zipkin');
 const Redis = require('redis');
 const zipkinClient = require('zipkin-instrumentation-redis');
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 const redisConnectionOptions = {
   host: 'localhost',
   port: '6379'

--- a/packages/zipkin-instrumentation-redis/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-redis/src/zipkinClient.js
@@ -4,7 +4,7 @@ module.exports = function zipkinClient(
   tracer,
   redis,
   options,
-  serviceName = 'unknown',
+  serviceName = tracer.localEndpoint.serviceName,
   remoteServiceName = 'redis'
 ) {
   const sa = {

--- a/packages/zipkin-instrumentation-request/README.md
+++ b/packages/zipkin-instrumentation-request/README.md
@@ -12,11 +12,11 @@ const request = require('request');
 
 const ctxImpl = new ExplicitContext();
 const recorder = new ConsoleRecorder();
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
-const serviceName = 'weather-app';
 const remoteServiceName = 'weather-api';
-const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
 
 zipkinRequest({
     url: 'http://api.weather.com',

--- a/packages/zipkin-instrumentation-request/index.d.ts
+++ b/packages/zipkin-instrumentation-request/index.d.ts
@@ -19,7 +19,7 @@ import {CoreOptions, Request, RequestAPI} from "request"
  */
 declare function wrapRequest<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions>(
   request: RequestAPI<TRequest, TOptions, TUriUrlOptions>,
-  options: {tracer: Tracer, serviceName?: string, remoteServiceName?: string}
+  options: {tracer: Tracer, remoteServiceName?: string}
 ): RequestAPI<TRequest, TOptions, TUriUrlOptions>;
 
 export = wrapRequest

--- a/packages/zipkin-instrumentation-request/src/wrapRequest.js
+++ b/packages/zipkin-instrumentation-request/src/wrapRequest.js
@@ -2,7 +2,7 @@ const {
   Instrumentation
 } = require('zipkin');
 
-function wrapRequest(request, {tracer, serviceName = 'unknown', remoteServiceName}) {
+function wrapRequest(request, {tracer, serviceName, remoteServiceName}) {
   const instrumentation = new Instrumentation.HttpClient({tracer, serviceName, remoteServiceName});
   return request.defaults((options, callback) => tracer.scoped(() => {
     const method = options.method || 'GET';

--- a/packages/zipkin-instrumentation-restify/README.md
+++ b/packages/zipkin-instrumentation-restify/README.md
@@ -11,14 +11,11 @@ const zipkinMiddleware = require('zipkin-instrumentation-restify').restifyMiddle
 
 const ctxImpl = new ExplicitContext();
 const recorder = new ConsoleRecorder();
-
-const tracer = new Tracer({ctxImpl, recorder}); // configure your tracer properly here
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const app = restify.createServer();
 
 // Add the Zipkin middleware
-app.use(zipkinMiddleware({
-  tracer,
-  serviceName: 'service-a' // name of this application
-}));
+app.use(zipkinMiddleware({tracer}));
 ```

--- a/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
+++ b/packages/zipkin-instrumentation-restify/src/restifyMiddleware.js
@@ -21,7 +21,7 @@ function formatRequestUrl(request) {
   });
 }
 
-module.exports = function restifyMiddleware({tracer, serviceName = 'unknown', port = 0}) {
+module.exports = function restifyMiddleware({tracer, serviceName, port = 0}) {
   return function zipkinRestifyMiddleware(req, res, next) {
     const instrumentation = new Instrumentation.HttpServer({tracer, serviceName, port});
     const readHeader = headerOption.bind(null, req);

--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -24,7 +24,8 @@ const recorder = new BatchRecorder({
 
 const tracer = new Tracer({
   recorder,
-  ctxImpl // this would typically be a CLSContext or ExplicitContext
+  ctxImpl, // this would typically be a CLSContext or ExplicitContext
+  localServiceName: 'service-a' // name of this application
 });
 ```
 

--- a/packages/zipkin-transport-kafka/README.md
+++ b/packages/zipkin-transport-kafka/README.md
@@ -19,8 +19,9 @@ const kafkaRecorder = new BatchRecorder({
 });
 
 const tracer = new Tracer({
-  recorder: kafkaRecorder,
-  ctxImpl // this would typically be a CLSContext or ExplicitContext
+  recorder,
+  ctxImpl, // this would typically be a CLSContext or ExplicitContext
+  localServiceName: 'service-a' // name of this application
 });
 ```
 

--- a/packages/zipkin-transport-scribe/README.md
+++ b/packages/zipkin-transport-scribe/README.md
@@ -19,7 +19,8 @@ const scribeRecorder = new BatchRecorder({
 });
 
 const tracer = new Tracer({
-  scribeRecorder,
-  ctxImpl // this would typically be a CLSContext or ExplicitContext
+  recorder,
+  ctxImpl, // this would typically be a CLSContext or ExplicitContext
+  localServiceName: 'service-a' // name of this application
 });
 ```

--- a/packages/zipkin/README.md
+++ b/packages/zipkin/README.md
@@ -23,6 +23,7 @@ const tracer = new zipkin.Tracer({
   ctxImpl,
   recorder: new zipkin.ConsoleRecorder(), // For easy debugging. You probably want to use an actual implementation, like Kafka or Scribe.
   sampler: new zipkin.sampler.CountingSampler(0.01), // sample rate 0.01 will sample 1 % of all incoming requests
-  traceId128Bit: true // to generate 128-bit trace IDs. 64-bit (false) is default
+  traceId128Bit: true, // to generate 128-bit trace IDs. 64-bit (false) is default
+  localServiceName: 'my-service' // indicates this node in your service graph
 });
 ```

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -30,7 +30,7 @@ declare namespace zipkin {
   }
 
   class Tracer {
-    constructor(args: { ctxImpl: Context<TraceId>, recorder: Recorder, sampler?: sampler.Sampler, traceId128Bit?: boolean });
+    constructor(args: { ctxImpl: Context<TraceId>, recorder: Recorder, sampler?: sampler.Sampler, traceId128Bit?: boolean, localServiceName?: string, localEndpoint?: model.Endpoint });
     id: TraceId;
 
     scoped<V>(callback: () => V): V;
@@ -282,7 +282,7 @@ declare namespace zipkin {
 
   namespace Instrumentation {
     class HttpServer {
-      constructor(args: { tracer: Tracer, serviceName: string, port: string | number });
+      constructor(args: { tracer: Tracer, port: number });
 
       recordRequest(
         method: string,
@@ -293,7 +293,7 @@ declare namespace zipkin {
     }
 
     class HttpClient {
-      constructor(args: { tracer: Tracer, serviceName: string, remoteServiceName?: string });
+      constructor(args: { tracer: Tracer, remoteServiceName?: string });
 
       recordRequest<T>(
         request: T,

--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -8,7 +8,7 @@ function requiredArg(name) {
 class HttpClientInstrumentation {
   constructor({
     tracer = requiredArg('tracer'),
-    serviceName = requiredArg('serviceName'),
+    serviceName = tracer.localEndpoint.serviceName,
     remoteServiceName
   }) {
     this.tracer = tracer;

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -26,7 +26,7 @@ function requiredArg(name) {
 class HttpServerInstrumentation {
   constructor({
     tracer = requiredArg('tracer'),
-    serviceName = requiredArg('serviceName'),
+    serviceName = tracer.localEndpoint.serviceName,
     port = requiredArg('port')
   }) {
     this.tracer = tracer;

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -6,6 +6,7 @@ const Annotation = require('../src/annotation');
 const {Sampler, neverSample} = require('../src/tracer/sampler');
 const ExplicitContext = require('../src/explicit-context');
 const {Some} = require('../src/option');
+const {Endpoint} = require('../src/model');
 
 describe('Tracer', () => {
   it('should make parent and child spans', () => {
@@ -77,6 +78,38 @@ describe('Tracer', () => {
 
       expect(record.getCall(0)).to.equal(null);
     });
+  });
+
+  it('should default to unknown endpoint', () => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const trace = new Tracer({ctxImpl, recorder});
+
+    expect(trace.localEndpoint).to.eql(new Endpoint({serviceName: 'unknown'}));
+  });
+
+  it('should accept localServiceName parameter', () => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const trace = new Tracer({ctxImpl, recorder, localServiceName: 'robot'});
+
+    expect(trace.localEndpoint).to.eql(new Endpoint({serviceName: 'robot'}));
+  });
+
+  it('should accept localEndpoint parameter', () => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const localEndpoint = new Endpoint({
+      serviceName: 'portal-service',
+      ipv4: '10.57.50.83',
+      port: 8080
+    });
+    const trace = new Tracer({ctxImpl, recorder, localEndpoint});
+
+    expect(trace.localEndpoint).to.eql(localEndpoint);
   });
 
   it('should log timestamps in microseconds', () => {


### PR DESCRIPTION
This adds `localServiceName` and `localEndpoint` constructor parameters to `Tracer`, which avoids repeating the same for all instrumentation.