### PR TITLE
Typescript declarations for zipkin-instrumentation-express and zipkin-instrumentation-request

### DIFF
--- a/packages/zipkin-instrumentation-express/index.d.ts
+++ b/packages/zipkin-instrumentation-express/index.d.ts
@@ -1,0 +1,22 @@
+import {Tracer} from "zipkin"
+import {Handler} from "express"
+
+/**
+ * When a request comes in, creates ServerRecv annotation and then passes
+ * the request to the next middlewhare. When the final middleware finishes
+ * the request, creates ServerSend annotation
+ *
+ * Sets the tracer.id to the span id prior to running the next middleware.
+ *
+ * Note that if the next middleware makes async calls, it should either
+ * store the span id manually or use a CLSContext so that the annotations
+ * go to the correct spans
+ */
+export declare function expressMiddleware(
+  options: {tracer: Tracer, serviceName?: string, port?: number}
+): Handler;
+
+export declare function wrapExpressHttpProxy(
+  proxy: (host: string, options?: any) => Handler,
+  options: {tracer: Tracer, serviceName?: string, remoteServiceName?: string}
+): (host: string, options?: any) => Handler

--- a/packages/zipkin-instrumentation-express/package.json
+++ b/packages/zipkin-instrumentation-express/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.1",
   "description": "Express middleware for instrumentation with Zipkin.js",
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "babel src -d lib",
     "test": "mocha --require ../../test/helper.js",
@@ -11,7 +12,11 @@
   "author": "OpenZipkin <openzipkin.alt@gmail.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
+  "peerDependencies": {
+    "@types/express": "^4.0.39"
+  },
   "devDependencies": {
+    "@types/express": "^4.0.39",
     "babel-cli": "^6.23.0",
     "express": "^4.13.4",
     "express-http-proxy": "^0.11.0",

--- a/packages/zipkin-instrumentation-request/index.d.ts
+++ b/packages/zipkin-instrumentation-request/index.d.ts
@@ -1,0 +1,25 @@
+import {Tracer} from "zipkin"
+import {CoreOptions, Request, RequestAPI} from "request"
+
+/**
+ * Wraps the request (or request-promise) api with HttpClient instrumentation
+ *
+ * Note: you may have to explicitly provide the generic types from request
+ * or request-promise to make the TypeScript compiler happy e.g., for request,
+ *
+ *     tracingRequest = wrapRequest<
+ *        request.Request, request.CoreOptions, request.RequiredUriUrl
+ *        >(request, {tracer})
+ *
+ * or, for request-promise,
+ *
+ *     tracingRequest = wrapRequest<
+ *        rp.RequestPromise, rp.RequestPromiseOptions, request.RequiredUriUrl
+ *        >(rp, {tracer})
+ */
+declare function wrapRequest<TRequest extends Request, TOptions extends CoreOptions, TUriUrlOptions>(
+  request: RequestAPI<TRequest, TOptions, TUriUrlOptions>,
+  options: {tracer: Tracer, serviceName?: string, remoteServiceName?: string}
+): RequestAPI<TRequest, TOptions, TUriUrlOptions>;
+
+export = wrapRequest

--- a/packages/zipkin-instrumentation-request/package.json
+++ b/packages/zipkin-instrumentation-request/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.1",
   "description": "Instrumentation for request with Zipkin.js",
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "babel src -d lib",
     "test": "mocha --require ../../test/helper.js",
@@ -11,7 +12,11 @@
   "author": "OpenZipkin <openzipkin.alt@gmail.com>",
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
+  "peerDependencies": {
+    "@types/request": "^2.0.8"
+  },
   "devDependencies": {
+    "@types/request": "^2.0.8",
     "babel-cli": "^6.23.0",
     "express": "^4.13.4",
     "mocha": "^3.2.0",

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -17,10 +17,12 @@ declare namespace zipkin {
   namespace sampler {
     class Sampler {
       constructor(evaluator: (traceId: TraceId) => boolean);
+      shouldSample(traceId: TraceId): option.IOption<boolean>
     }
 
     class CountingSampler implements Sampler {
       constructor(sampleRate?: number);
+      shouldSample(traceId: TraceId): option.IOption<boolean>
     }
 
     const neverSample: (traceId: TraceId) => boolean;
@@ -54,11 +56,11 @@ declare namespace zipkin {
     _sampled:  option.IOption<boolean>;
     _flags:    number;
 
-    traceId:  string;
-    parentId: string;
-    spanId:   string;
-    sampled:  boolean;
-    flags:    number;
+    readonly traceId: string;
+    readonly parentId: string;
+    readonly spanId: string;
+    readonly sampled: option.IOption<boolean>;
+    readonly flags: number;
 
     isDebug(): boolean;
 
@@ -69,11 +71,6 @@ declare namespace zipkin {
       sampled?:  option.IOption<string>,
       flags?:    number
     });
-    readonly spanId: string;
-    readonly parentId: string;
-    readonly traceId: string;
-    readonly sampled: option.IOption<boolean>;
-    readonly flags: number;
     isDebug(): boolean;
     toString(): string;
   }
@@ -120,7 +117,7 @@ declare namespace zipkin {
   }
 
   namespace model {
-    interface Endpoint {
+    class Endpoint {
       constructor(args: { serviceName?: string, ipv4?: InetAddress, port?: number });
 
       setServiceName(serviceName: string): void;
@@ -135,7 +132,7 @@ declare namespace zipkin {
       value: string;
     }
 
-    interface Span {
+    class Span {
       readonly traceId:        string;
       readonly parentId?:      string;
       readonly id:             string;
@@ -270,19 +267,6 @@ declare namespace zipkin {
     getContext(): TraceId;
     scoped<V>(callback: () => V): V;
     letContext<V>(ctx: TraceId, callback: () => V): V;
-  }
-
-  namespace sampler {
-    class Sampler {
-      constructor(evaluator: (traceId: TraceId) => boolean)
-      shouldSample(traceId: TraceId): option.IOption<boolean>
-      toString(): String
-    }
-    function neverSample(traceId: TraceId): boolean
-    function alwaysSample(traceId: TraceId): boolean
-    class CountingSampler extends Sampler {
-      constructor(sampleRate: number)
-    }
   }
 
   class Request {

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -269,7 +269,8 @@ declare namespace zipkin {
     letContext<V>(ctx: TraceId, callback: () => V): V;
   }
 
-  class Request {
+  namespace Request {
+    function addZipkinHeaders(req: {headers: any}, traceId: TraceId): void;
   }
 
   /** The Logger (or transport) is what the Recorder uses to send spans to Zipkin.


### PR DESCRIPTION
Fix `packages/zipkin/index.d.ts`, which had some duplicate declarations because pawel’s commit dc62adeb3dc47eafff02abedff50356ba5f8278f was rebased on top of my commits 95abee9f43165cd30e9066567df260e66a8e1ee1, e387cfa9ea4c7c14b5d1650c062ed253818e54b0, fedc9bc2ed10dad9de429df5b5cef84d89324a70.

Add typescript declarations for zipkin-instrumentation-express and zipkin-instrumentation-request