### PR TITLE
add support for optional fetch timeout

### DIFF
--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,7 +1,7 @@
 import {JsonEncoder, Logger, model} from "zipkin"
 
 declare class HttpLogger implements Logger {
-  constructor(options: {endpoint: string, httpInterval?: number, jsonEncoder?: JsonEncoder});
+  constructor(options: {endpoint: string, httpInterval?: number, jsonEncoder?: JsonEncoder, httpTimeout?: number});
   logSpan(span: model.Span): void;
 }
 export {HttpLogger}


### PR DESCRIPTION
had some trouble figuring out how to test this.. any suggestions? I started down the path of something like:

```javascript
it('should abort the request if response exceeds timeout', function(done) {
  // ..
  app.post('/api/v1/spans', (req, res) => {
    setTimeout(() => { res.status(202).json({}); }, 61000);
  });
  // ...
  this.server = app.listen(0, () => {
    // ..
    const httpLogger = new HttpLogger({
      endpoint: `http://localhost:${this.port}/api/v1/spans`,
      headers: {Authorization: 'Token'},
      jsonEncoder: JSON_V2,
      timeout: 2000,
    });
    // .. 
  });
});
```

But I'm not sure how to get a reference to the promise returned by fetch.. any advice would be welcome!

closes #163