### PR TITLE
TypeScript type fix, and add fields

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -193,16 +193,19 @@ declare namespace zipkin {
     class Message implements IAnnotation {
       constructor(message: string);
       readonly annotationType: string;
+      message: string;
     }
 
     class ServiceName implements IAnnotation {
       constructor(serviceName: string);
       readonly annotationType: string;
+      serviceName: string;
     }
 
     class Rpc implements IAnnotation {
       constructor(name: string);
       readonly annotationType: string;
+      name: string;
     }
 
     class ClientAddr implements IAnnotation {
@@ -213,16 +216,23 @@ declare namespace zipkin {
     class ServerAddr implements IAnnotation {
       constructor(args: { serviceName: string, host?: InetAddress, port?: number });
       readonly annotationType: string;
+      serviceName: string
+      host: InetAddress;
+      port: number;
     }
 
     class LocalAddr implements IAnnotation {
       constructor(args?: { host?: InetAddress, port?: number });
       readonly annotationType: string;
+      host: InetAddress;
+      port: number;
     }
 
     class BinaryAnnotation implements IAnnotation {
       constructor(key: string, value: boolean | string | number);
       readonly annotationType: string;
+      key: string;
+      value: string;
     }
   }
 

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -119,7 +119,7 @@ declare namespace zipkin {
 
   namespace model {
     class Endpoint {
-      constructor(args: { serviceName?: string, ipv4?: InetAddress, port?: number });
+      constructor(args: { serviceName?: string, ipv4?: string, port?: number });
 
       setServiceName(serviceName: string): void;
       setIpv4(ipv4: string): void;


### PR DESCRIPTION
Fix the type of ipv4 for Endpoint constructor

Add fields of the Annotation subclasses