### PR TITLE
Trades unused letChildId for letId

### DIFF
--- a/packages/zipkin-instrumentation-memcached/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-memcached/src/zipkinClient.js
@@ -8,8 +8,7 @@ module.exports = function zipkinClient(
 ) {
   function mkZipkinCallback(callback, id) {
     return function zipkinCallback(...args) {
-      tracer.scoped(() => {
-        tracer.setId(id);
+      tracer.letId(id, () => {
         // TODO: parse host and port from details in callback
         // https://github.com/3rd-Eden/memcached#details-object
         tracer.recordAnnotation(new Annotation.ServerAddr({
@@ -53,10 +52,8 @@ module.exports = function zipkinClient(
     const actualFn = ZipkinMemcached.prototype[key];
     ZipkinMemcached.prototype[key] = function(...args) {
       const callback = args.pop();
-      let id;
-      tracer.scoped(() => {
-        id = tracer.createChildId();
-        tracer.setId(id);
+      const id = tracer.createChildId();
+      tracer.letId(id, () => {
         commonAnnotations(key);
         if (annotator) {
           annotator.apply(this, args);

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -37,7 +37,7 @@ declare namespace zipkin {
     local<V>(name: string, callback: () => V): V;
     createRootId(): TraceId;
     createChildId(): TraceId;
-    letChildId<V>(callback: (traceId: TraceId) => V): V;
+    letId<V>(traceId: TraceId, callback: () => V): V;
     setId(traceId: TraceId): void;
     recordAnnotation(annotation: IAnnotation): void;
     recordMessage(message: any): void;

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -47,6 +47,10 @@ class Tracer {
     return this._ctxImpl.scoped(callback);
   }
 
+  letId(id, callback) {
+    return this._ctxImpl.letContext(id, callback);
+  }
+
   createRootId() {
     const rootSpanId = randomTraceId();
     const traceId = this.traceId128Bit
@@ -131,14 +135,6 @@ class Tracer {
           explicitRecord(new Annotation.LocalOperationStop());
           throw err;
         });
-    });
-  }
-
-  letChildId(callable) {
-    return this.scoped(() => {
-      const traceId = this.createChildId();
-      this.setId(traceId);
-      return callable(traceId);
     });
   }
 

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -40,6 +40,32 @@ describe('Tracer', () => {
     });
   });
 
+  it('should clear scope after letId', () => {
+    const recorder = {
+      record: () => {}
+    };
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({ctxImpl, recorder});
+
+    ctxImpl.scoped(() => {
+      const parentId = tracer.createRootId();
+      const childId = tracer.createChildId();
+
+      tracer.setId(parentId);
+      tracer.letId(childId, () => {
+        expect(tracer.id).to.equal(childId);
+
+        tracer.letId(parentId, () => {
+          expect(tracer.id).to.equal(parentId);
+        });
+
+        expect(tracer.id).to.equal(childId);
+      });
+
+      expect(tracer.id).to.equal(parentId);
+    });
+  });
+
   it('should make a local span', () => {
     const record = sinon.spy();
     const recorder = {record};


### PR DESCRIPTION
This adds letId which is a shortcut to combining tracer.scoped with
setId. It pays for the additional code by removing an unused function:
tracer.letChildId