### PR TITLE
Fix memory leak for not closing kafka producer listeners

### DIFF
--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -23,7 +23,7 @@ module.exports = class KafkaLogger {
       }
       const producer = new kafka.HighLevelProducer(this.client, producerOpts);
       producer.on('ready', () => resolve(producer));
-      producer.on('error', reject);
+      producer.on('error', reject(producer));
     });
   }
 
@@ -35,7 +35,7 @@ module.exports = class KafkaLogger {
         messages: data
       }], () => {});
       producer.removeAllListeners();
-    }).catch(() => { producer.removeAllListeners(); });
+    }).catch((producer) => { producer.removeAllListeners(); });
   }
 
   close() {

--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -23,7 +23,7 @@ module.exports = class KafkaLogger {
       }
       const producer = new kafka.HighLevelProducer(this.client, producerOpts);
       producer.on('ready', () => resolve(producer));
-      producer.on('error', reject(producer));
+      producer.on('error', () => reject(producer));
     });
   }
 

--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -34,7 +34,8 @@ module.exports = class KafkaLogger {
         topic: this.topic,
         messages: data
       }], () => {});
-    });
+      producer.removeAllListeners();
+    }).catch(() => { producer.removeAllListeners(); });
   }
 
   close() {


### PR DESCRIPTION
Remove listeners when producer sends or fails to send, to avoid memory leaks when trace has a lot of spans.