### PR TITLE
Fix return type of HttpServer.recordRequest

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -299,7 +299,7 @@ declare namespace zipkin {
         method: string,
         requestUrl: string,
         readHeader: <T> (header: string) => option.IOption<T>
-      ): string;
+      ): TraceId;
       recordResponse(traceId: string, statusCode: string, error?: Error): void;
     }
 

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -300,7 +300,7 @@ declare namespace zipkin {
         requestUrl: string,
         readHeader: <T> (header: string) => option.IOption<T>
       ): TraceId;
-      recordResponse(traceId: string, statusCode: string, error?: Error): void;
+      recordResponse(traceId: TraceId, statusCode: string, error?: Error): void;
     }
 
     class HttpClient {
@@ -311,8 +311,8 @@ declare namespace zipkin {
         url: string,
         method: string
       ): T;
-      recordResponse(traceId: string, statusCode: string): void;
-      recordError(traceId: string, error: Error): void;
+      recordResponse(traceId: TraceId, statusCode: string): void;
+      recordError(traceId: TraceId, error: Error): void;
     }
   }
 }


### PR DESCRIPTION
Instrumentation.HttpServer.recordRequest returns a TraceId object, not a string.
Instrumentation.HttpClient/HttpClient.recordResponse takes a TraceId object, not a string.