### PR TITLE
CLSContext now supports continuations with async-await

### DIFF
--- a/packages/zipkin-context-cls/package.json
+++ b/packages/zipkin-context-cls/package.json
@@ -13,6 +13,11 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "continuation-local-storage": "^3.1.7"
+    "cls-hooked": "^4.2.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "babel-eslint": "^8.2.2",
+    "mocha": "^3.2.0"
   }
 }

--- a/packages/zipkin-context-cls/src/CLSContext.js
+++ b/packages/zipkin-context-cls/src/CLSContext.js
@@ -1,4 +1,4 @@
-const {createNamespace, getNamespace} = require('continuation-local-storage');
+const {createNamespace, getNamespace} = require('cls-hooked');
 
 module.exports = class CLSContext {
   constructor(namespace = 'zipkin') {

--- a/packages/zipkin-context-cls/test/.eslintrc
+++ b/packages/zipkin-context-cls/test/.eslintrc
@@ -4,5 +4,6 @@
   },
   "globals": {
     "expect": true
-  }
+  },
+  "parser": "babel-eslint"
 }

--- a/packages/zipkin-context-cls/test/CLSContext.test.js
+++ b/packages/zipkin-context-cls/test/CLSContext.test.js
@@ -80,4 +80,24 @@ describe('CLSContext', () => {
       setTimeout(callback, 10);
     });
   });
+  it('should support async-await', async () => {
+    const ctx = new CLSContext();
+
+    async function log() {
+      return ctx.getContext();
+    }
+
+    async function afn() {
+      const cid1 = await log(1);
+      const cid2 = await log(2);
+      return {cid1, cid2};
+    }
+
+    async function newP(id) {
+      const {cid1, cid2} = await ctx.letContext(id, () => afn());
+      expect(cid1).to.not.equal(null);
+      expect(cid2).to.not.equal(null);
+    }
+    await newP(1); // eslint-disable-line
+  });
 });


### PR DESCRIPTION
`continuation-local-storage` has issues with `async-await` so someone made a library called [cls-hooked](https://www.npmjs.com/package/cls-hooked) which fixes that problem.

This PR merely changes the dependency from `cls` to `cls-hooked`.

Also, added a test case to demonstrate the phenomenon. 

Possible duplicate #135 