### PR TITLE
kafkaLogger unhandled error in promise fix

### DIFF
--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -12,30 +12,44 @@ module.exports = class KafkaLogger {
       requireAcks: 0
     };
     const producerOpts = Object.assign({}, producerDefaults, options.producerOpts || {});
-    this.producerPromise = new Promise((resolve, reject) => {
-      this.topic = options.topic || 'zipkin';
-      if (clientOpts.connectionString) {
-        this.client = new kafka.Client(
-          clientOpts.connectionString, clientOpts.clientId, clientOpts.zkOpts
-        );
-      } else {
-        this.client = new kafka.KafkaClient(clientOpts);
-      }
-      const producer = new kafka.HighLevelProducer(this.client, producerOpts);
-      producer.on('ready', () => resolve(producer));
-      producer.on('error', () => reject(producer));
+    this.onProducerError = options.onProducerError || function(err) { console.error(err); };
+
+    this.topic = options.topic || 'zipkin';
+    if (clientOpts.connectionString) {
+      this.client = new kafka.Client(
+        clientOpts.connectionString, clientOpts.clientId, clientOpts.zkOpts,
+      );
+    } else {
+      this.client = new kafka.KafkaClient(clientOpts);
+    }
+    this.producer = new kafka.HighLevelProducer(this.client, producerOpts);
+    this.producerState = 'pending';
+    
+    this.producer.on('ready', () => {
+      this.producerState = 'ready';
+      this.producer.removeAllListeners('ready');
     });
+
+    this.producer.on('error', this.onProducerError);
   }
 
   logSpan(span) {
-    this.producerPromise.then(producer => {
       const data = THRIFT.encode(span);
-      producer.send([{
-        topic: this.topic,
-        messages: data
-      }], () => {});
-      producer.removeAllListeners();
-    }).catch((producer) => { producer.removeAllListeners(); });
+      if (this.producerState === 'ready') {
+        this.producer.send([{
+          topic: this.topic,
+          messages: data,
+        }], () => {});
+      } else {
+        this.producer.on('ready', () => {
+          this.producerState = 'ready';
+          this.producer.send([{
+            topic: this.topic,
+            messages: data,
+          }], () => {});
+          this.producer.removeAllListeners('ready');
+        });
+      }
   }
 
   close() {


### PR DESCRIPTION
Removed promise in KafkaLogger.js and provide access to the producer within logSpan. onError is always bound to the producer (not sure why removeAllListeners is ever called), and can be defined in the constructor. 