### PR TITLE
added message tracing annotations

### DIFF
--- a/packages/zipkin/src/annotation.js
+++ b/packages/zipkin/src/annotation.js
@@ -9,10 +9,10 @@ class ClientSend extends SimpleAnnotation {}
 class ClientRecv extends SimpleAnnotation {}
 class ServerSend extends SimpleAnnotation {}
 class ServerRecv extends SimpleAnnotation {}
-class MessageSend extends SimpleAnnotation {}
-class MessageRecv extends SimpleAnnotation {}
-class WireSend extends SimpleAnnotation {}
-class WireRecv extends SimpleAnnotation {}
+class ProducerStart extends SimpleAnnotation {}
+class ProducerStop extends SimpleAnnotation {}
+class ConsumerStart extends SimpleAnnotation {}
+class ConsumerStop extends SimpleAnnotation {}
 
 function LocalOperationStart(name) {
   this.name = name;
@@ -82,10 +82,10 @@ const annotation = {
   ClientRecv,
   ServerSend,
   ServerRecv,
-  MessageSend,
-  MessageRecv,
-  WireSend,
-  WireRecv,
+  ProducerStart,
+  ProducerStop,
+  ConsumerStart,
+  ConsumerStop,
   Message,
   ServiceName,
   Rpc,

--- a/packages/zipkin/src/annotation.js
+++ b/packages/zipkin/src/annotation.js
@@ -9,6 +9,10 @@ class ClientSend extends SimpleAnnotation {}
 class ClientRecv extends SimpleAnnotation {}
 class ServerSend extends SimpleAnnotation {}
 class ServerRecv extends SimpleAnnotation {}
+class MessageSend extends SimpleAnnotation {}
+class MessageRecv extends SimpleAnnotation {}
+class WireSend extends SimpleAnnotation {}
+class WireRecv extends SimpleAnnotation {}
 
 function LocalOperationStart(name) {
   this.name = name;
@@ -78,6 +82,10 @@ const annotation = {
   ClientRecv,
   ServerSend,
   ServerRecv,
+  MessageSend,
+  MessageRecv,
+  WireSend,
+  WireRecv,
   Message,
   ServiceName,
   Rpc,

--- a/packages/zipkin/src/annotation.js
+++ b/packages/zipkin/src/annotation.js
@@ -69,6 +69,15 @@ LocalAddr.prototype.toString = function() {
   return `LocalAddr(host="${this.host.toString()}", port=${this.port})`;
 };
 
+function MessageAddr({serviceName, host, port}) {
+  this.serviceName = serviceName;
+  this.host = host;
+  this.port = port;
+}
+MessageAddr.prototype.toString = function() {
+  return `MessageAddr(serviceName="${this.serviceName}", host="${this.host}", port=${this.port})`;
+};
+
 function BinaryAnnotation(key, value) {
   this.key = key;
   this.value = value;
@@ -86,6 +95,7 @@ const annotation = {
   ProducerStop,
   ConsumerStart,
   ConsumerStop,
+  MessageAddr,
   Message,
   ServiceName,
   Rpc,

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -99,6 +99,18 @@ class BatchRecorder {
           span.delegate.setShared(id.parentId !== id.spanId);
           span.delegate.setKind('CLIENT');
           break;
+        case 'MessageSend':
+          span.finish();
+          span.delegate.setKind('PRODUCER');
+          break;
+        case 'WireSend':
+          break;
+        case 'WireRecv':
+          break;
+        case 'MessageRecv':
+          span.finish();
+          span.delegate.setKind('CONSUMER');
+          break;
         case 'LocalOperationStart':
           span.delegate.setName(rec.annotation.name);
           break;

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -99,15 +99,17 @@ class BatchRecorder {
           span.delegate.setShared(id.parentId !== id.spanId);
           span.delegate.setKind('CLIENT');
           break;
-        case 'MessageSend':
+        case 'ProducerStart':
+          span.delegate.setKind('PRODUCER');
+          break;
+        case 'ProducerStop':
           span.finish();
           span.delegate.setKind('PRODUCER');
           break;
-        case 'WireSend':
+        case 'ConsumerStart':
+          span.delegate.setKind('CONSUMER');
           break;
-        case 'WireRecv':
-          break;
-        case 'MessageRecv':
+        case 'ConsumerStop':
           span.finish();
           span.delegate.setKind('CONSUMER');
           break;

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -113,6 +113,13 @@ class BatchRecorder {
           span.finish();
           span.delegate.setKind('CONSUMER');
           break;
+        case 'MessageAddr':
+          span.delegate.setRemoteEndpoint(new Endpoint({
+            serviceName: rec.annotation.serviceName,
+            ipv4: rec.annotation.host && rec.annotation.host.ipv4(),
+            port: rec.annotation.port
+          }));
+          break;
         case 'LocalOperationStart':
           span.delegate.setName(rec.annotation.name);
           break;

--- a/packages/zipkin/src/jsonEncoder.js
+++ b/packages/zipkin/src/jsonEncoder.js
@@ -54,6 +54,20 @@ function encodeV1(span) {
       endAnnotation = 'ss';
       addressKey = 'ca';
       break;
+    case 'PRODUCER':
+      beginAnnotation = span.timestamp ? 'ms' : undefined;
+      endAnnotation = 'ws';
+      addressKey = 'ma';
+      break;
+    case 'CONSUMER':
+      if (span.timestamp && span.duration) {
+        beginAnnotation = 'wr';
+        endAnnotation = 'mr';
+      } else if (span.timestamp) {
+        beginAnnotation = 'mr';
+      }
+      addressKey = 'ma';
+      break;
     default:
   }
 


### PR DESCRIPTION
Hi,

  I added the `MessageSend`, `MessageRecv`, `WireSend`, `WireRecv` annotation type to support message tracing. Referenced the discussion in #215 

  One thing I'm still not sure is how to handle `WireSend` and `WireRecv` spans in `batch-recorder.js`, can someone give me some help on this part? I'd like very much to finish this feature and get the PR merged.

Thanks!