### PR TITLE
Adds headers option to HttpLogger types

### DIFF
--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,7 +1,7 @@
 import {JsonEncoder, Logger, model} from "zipkin"
 
 declare class HttpLogger implements Logger {
-  constructor(options: {endpoint: string, httpInterval?: number, jsonEncoder?: JsonEncoder, httpTimeout?: number});
+  constructor(options: {endpoint: string, httpInterval?: number, jsonEncoder?: JsonEncoder, httpTimeout?: number, headers?: { [name: string]: any }});
   logSpan(span: model.Span): void;
 }
 export {HttpLogger}


### PR DESCRIPTION
The HttpLogger accepts an option of Http headers to add to the outgoing request. This adds support for that option to the accompanying type definition file.