### PR TITLE
[Issue #217] Remove http.url annotation in favor of http.path and http.host

### DIFF
--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -27,8 +27,10 @@ describe('cujojs rest interceptor - integration test', () => {
           remoteServiceName: 'callee'
         });
         const port = server.address().port;
-        const path = `http://127.0.0.1:${port}/abc`;
-        client(path).then(successResponse => {
+        const host = '127.0.0.1';
+        const urlPath = '/abc';
+        const url = `http://${host}:${port}${urlPath}`;
+        client(url).then(successResponse => {
           const responseData = JSON.parse(successResponse.entity);
           server.close();
 
@@ -47,19 +49,23 @@ describe('cujojs rest interceptor - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(path);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[4].annotation.serviceName).to.equal('callee');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.serviceName).to.equal('callee');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
           const traceIdOnServer = responseData.traceId;
           expect(traceIdOnServer).to.equal(traceId);

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -52,20 +52,16 @@ describe('cujojs rest interceptor - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.serviceName).to.equal('callee');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[5].annotation.serviceName).to.equal('callee');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
           const traceIdOnServer = responseData.traceId;
           expect(traceIdOnServer).to.equal(traceId);

--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -32,7 +32,6 @@ class ExpressHttpProxyInstrumentation {
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(proxyReq.method.toUpperCase());
     this.tracer.recordBinary('http.path', getPathnameFromPath(proxyReq.path));
-    this.tracer.recordBinary('http.host', proxyReq.hostname);
     this.tracer.recordAnnotation(new Annotation.ClientSend());
     if (this.remoteServiceName) {
       this.tracer.recordAnnotation(new Annotation.ServerAddr({

--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -1,9 +1,9 @@
 const {Request, Annotation} = require('zipkin');
 const url = require('url');
 
-function getPathnameFromPath (path) {
+function getPathnameFromPath(path) {
   const parsedPath = url.parse(path);
-  return parsedPath.pathname
+  return parsedPath.pathname;
 }
 
 class ExpressHttpProxyInstrumentation {

--- a/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
@@ -59,23 +59,19 @@ describe('express middleware - integration test', () => {
             expect(annotations[2].annotation.key).to.equal('http.path');
             expect(annotations[2].annotation.value).to.equal(urlPath);
 
-            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[3].annotation.key).to.equal('http.host');
-            expect(annotations[3].annotation.value).to.equal(host);
+            expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-            expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+            expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-            expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+            expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[5].annotation.key).to.equal('message');
+            expect(annotations[5].annotation.value).to.equal('hello from within app');
 
             expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[6].annotation.key).to.equal('message');
-            expect(annotations[6].annotation.value).to.equal('hello from within app');
+            expect(annotations[6].annotation.key).to.equal('http.status_code');
+            expect(annotations[6].annotation.value).to.equal('202');
 
-            expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[7].annotation.key).to.equal('http.status_code');
-            expect(annotations[7].annotation.value).to.equal('202');
-
-            expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+            expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
             done();
           })
           .catch(err => {
@@ -124,10 +120,6 @@ describe('express middleware - integration test', () => {
             expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
             expect(annotations[2].annotation.key).to.equal('http.path');
             expect(annotations[2].annotation.value).to.equal(urlPath);
-
-            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[3].annotation.key).to.equal('http.host');
-            expect(annotations[3].annotation.value).to.equal(host);
 
             done();
           })

--- a/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
@@ -29,7 +29,9 @@ describe('express middleware - integration test', () => {
       });
       const server = app.listen(0, () => {
         const port = server.address().port;
-        const url = `http://127.0.0.1:${port}/foo`;
+        const host = '127.0.0.1';
+        const urlPath = '/foo';
+        const url = `http://${host}:${port}${urlPath}`;
         fetch(url, {
           method: 'post'
         }).then(res => res.json())
@@ -54,22 +56,26 @@ describe('express middleware - integration test', () => {
             expect(annotations[1].annotation.name).to.equal('POST');
 
             expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[2].annotation.key).to.equal('http.url');
-            expect(annotations[2].annotation.value).to.equal(url);
+            expect(annotations[2].annotation.key).to.equal('http.path');
+            expect(annotations[2].annotation.value).to.equal(urlPath);
 
-            expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[3].annotation.key).to.equal('http.host');
+            expect(annotations[3].annotation.value).to.equal(host);
 
-            expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+            expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-            expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[5].annotation.key).to.equal('message');
-            expect(annotations[5].annotation.value).to.equal('hello from within app');
+            expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
             expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[6].annotation.key).to.equal('http.status_code');
-            expect(annotations[6].annotation.value).to.equal('202');
+            expect(annotations[6].annotation.key).to.equal('message');
+            expect(annotations[6].annotation.value).to.equal('hello from within app');
 
-            expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
+            expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[7].annotation.key).to.equal('http.status_code');
+            expect(annotations[7].annotation.value).to.equal('202');
+
+            expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
             done();
           })
           .catch(err => {
@@ -104,7 +110,9 @@ describe('express middleware - integration test', () => {
       });
       const server = app.listen(0, () => {
         const port = server.address().port;
-        const url = `http://127.0.0.1:${port}/foo?abc=123`;
+        const host = '127.0.0.1';
+        const urlPath = '/foo';
+        const url = `http://${host}:${port}${urlPath}?abc=123`;
         fetch(url, {
           method: 'get'
         }).then(res => res.json())
@@ -114,8 +122,13 @@ describe('express middleware - integration test', () => {
             const annotations = record.args.map(args => args[0]);
 
             expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[2].annotation.key).to.equal('http.url');
-            expect(annotations[2].annotation.value).to.equal(url);
+            expect(annotations[2].annotation.key).to.equal('http.path');
+            expect(annotations[2].annotation.value).to.equal(urlPath);
+
+            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[3].annotation.key).to.equal('http.host');
+            expect(annotations[3].annotation.value).to.equal(host);
+
             done();
           })
           .catch(err => {

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -29,7 +29,7 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1'
+        const apiHost = '127.0.0.1';
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
@@ -48,7 +48,7 @@ describe('express http proxy instrumentation - integration test', () => {
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const urlPath = '/weather'
+          const urlPath = '/weather';
           const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url)
             .then(res => res.json())
@@ -109,7 +109,7 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1'
+        const apiHost = '127.0.0.1';
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
@@ -117,7 +117,7 @@ describe('express http proxy instrumentation - integration test', () => {
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const urlPath = '/weather'
+          const urlPath = '/weather';
           const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url)
             .then(res => res.json())
@@ -178,7 +178,7 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1'
+        const apiHost = '127.0.0.1';
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
@@ -197,7 +197,7 @@ describe('express http proxy instrumentation - integration test', () => {
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const urlPath = '/weather'
+          const urlPath = '/weather';
           const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url, {
             method: 'put',

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -29,10 +29,11 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1'
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
-        app.use(zipkinProxy(`127.0.0.1:${apiPort}`, {
+        app.use(zipkinProxy(`${apiHost}:${apiPort}`, {
           decorateRequest: (proxyReq) => {
             const modifiedReq = proxyReq;
             modifiedReq.method = 'POST';
@@ -47,7 +48,8 @@ describe('express http proxy instrumentation - integration test', () => {
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const url = `http://127.0.0.1:${appPort}/weather?index=10&count=300`;
+          const urlPath = '/weather'
+          const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url)
             .then(res => res.json())
             .then(() => {
@@ -67,20 +69,22 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[1].annotation.name).to.equal('POST');
 
               expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[2].annotation.key).to.equal('http.url');
-              // express-http-proxy does not include protocol when intercepting request
-              const apiUrlWithoutProtocol = `//127.0.0.1:${apiPort}/weather?index=10&count=300`;
-              expect(annotations[2].annotation.value).to.equal(apiUrlWithoutProtocol);
+              expect(annotations[2].annotation.key).to.equal('http.path');
+              expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[3].annotation.key).to.equal('http.host');
+              expect(annotations[3].annotation.value).to.equal(apiHost);
 
-              expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[5].annotation.key).to.equal('http.status_code');
-              expect(annotations[5].annotation.value).to.equal('203');
+              expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-              expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+              expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[6].annotation.key).to.equal('http.status_code');
+              expect(annotations[6].annotation.value).to.equal('203');
+
+              expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
               done();
             })
             .catch(err => {
@@ -105,14 +109,16 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1'
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
-        app.use(zipkinProxy(`127.0.0.1:${apiPort}`));
+        app.use(zipkinProxy(`${apiHost}:${apiPort}`));
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const url = `http://127.0.0.1:${appPort}/weather?index=10&count=300`;
+          const urlPath = '/weather'
+          const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url)
             .then(res => res.json())
             .then(() => {
@@ -132,20 +138,22 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[1].annotation.name).to.equal('GET');
 
               expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[2].annotation.key).to.equal('http.url');
-              // express-http-proxy does not include protocol when intercepting request
-              const apiUrlWithoutProtocol = `//127.0.0.1:${apiPort}/weather?index=10&count=300`;
-              expect(annotations[2].annotation.value).to.equal(apiUrlWithoutProtocol);
+              expect(annotations[2].annotation.key).to.equal('http.path');
+              expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[3].annotation.key).to.equal('http.host');
+              expect(annotations[3].annotation.value).to.equal(apiHost);
 
-              expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[5].annotation.key).to.equal('http.status_code');
-              expect(annotations[5].annotation.value).to.equal('202');
+              expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-              expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+              expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[6].annotation.key).to.equal('http.status_code');
+              expect(annotations[6].annotation.value).to.equal('202');
+
+              expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
               done();
             })
             .catch(err => {
@@ -170,10 +178,11 @@ describe('express http proxy instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const app = express();
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1'
 
         const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
 
-        app.use(middleware({tracer, serviceName}), zipkinProxy(`127.0.0.1:${apiPort}`, {
+        app.use(middleware({tracer, serviceName}), zipkinProxy(`${apiHost}:${apiPort}`, {
           decorateRequest: (proxyReq) => {
             const modifiedReq = proxyReq;
             modifiedReq.method = 'POST';
@@ -188,7 +197,8 @@ describe('express http proxy instrumentation - integration test', () => {
 
         const appServer = app.listen(0, () => {
           const appPort = appServer.address().port;
-          const url = `http://127.0.0.1:${appPort}/weather?index=10&count=300`;
+          const urlPath = '/weather'
+          const url = `http://${apiHost}:${appPort}${urlPath}?index=10&count=300`;
           fetch(url, {
             method: 'put',
             headers: {
@@ -212,40 +222,46 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[1].annotation.name).to.equal('PUT');
 
               expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[2].annotation.key).to.equal('http.url');
-              expect(annotations[2].annotation.value).to.equal(url);
+              expect(annotations[2].annotation.key).to.equal('http.path');
+              expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[3].annotation.key).to.equal('http.host');
+              expect(annotations[3].annotation.value).to.equal(apiHost);
 
-              expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+              expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-              expect(annotations[5].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[5].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
-              expect(annotations[6].annotation.annotationType).to.equal('Rpc');
-              expect(annotations[6].annotation.name).to.equal('POST');
+              expect(annotations[6].annotation.annotationType).to.equal('ServiceName');
+              expect(annotations[6].annotation.serviceName).to.equal('weather-app');
 
-              expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[7].annotation.key).to.equal('http.url');
-              // express-http-proxy does not include protocol when intercepting request
-              const apiUrlWithoutProtocol = `//127.0.0.1:${apiPort}/weather?index=10&count=300`;
-              expect(annotations[7].annotation.value).to.equal(apiUrlWithoutProtocol);
+              expect(annotations[7].annotation.annotationType).to.equal('Rpc');
+              expect(annotations[7].annotation.name).to.equal('POST');
 
-              expect(annotations[8].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[8].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[8].annotation.key).to.equal('http.path');
+              expect(annotations[8].annotation.value).to.equal(urlPath);
 
-              expect(annotations[9].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[9].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[9].annotation.key).to.equal('http.host');
+              expect(annotations[9].annotation.value).to.equal(apiHost);
 
-              expect(annotations[10].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[10].annotation.key).to.equal('http.status_code');
-              expect(annotations[10].annotation.value).to.equal('202');
+              expect(annotations[10].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[11].annotation.annotationType).to.equal('ClientRecv');
+              expect(annotations[11].annotation.annotationType).to.equal('ServerAddr');
 
               expect(annotations[12].annotation.annotationType).to.equal('BinaryAnnotation');
               expect(annotations[12].annotation.key).to.equal('http.status_code');
-              expect(annotations[12].annotation.value).to.equal('203');
+              expect(annotations[12].annotation.value).to.equal('202');
 
-              expect(annotations[13].annotation.annotationType).to.equal('ServerSend');
+              expect(annotations[13].annotation.annotationType).to.equal('ClientRecv');
+
+              expect(annotations[14].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[14].annotation.key).to.equal('http.status_code');
+              expect(annotations[14].annotation.value).to.equal('203');
+
+              expect(annotations[15].annotation.annotationType).to.equal('ServerSend');
 
               done();
             })

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -72,19 +72,15 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[2].annotation.key).to.equal('http.path');
               expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[3].annotation.key).to.equal('http.host');
-              expect(annotations[3].annotation.value).to.equal(apiHost);
+              expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-              expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[5].annotation.key).to.equal('http.status_code');
+              expect(annotations[5].annotation.value).to.equal('203');
 
-              expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[6].annotation.key).to.equal('http.status_code');
-              expect(annotations[6].annotation.value).to.equal('203');
-
-              expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+              expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
               done();
             })
             .catch(err => {
@@ -141,19 +137,15 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[2].annotation.key).to.equal('http.path');
               expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[3].annotation.key).to.equal('http.host');
-              expect(annotations[3].annotation.value).to.equal(apiHost);
+              expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-              expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[5].annotation.key).to.equal('http.status_code');
+              expect(annotations[5].annotation.value).to.equal('202');
 
-              expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[6].annotation.key).to.equal('http.status_code');
-              expect(annotations[6].annotation.value).to.equal('202');
-
-              expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+              expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
               done();
             })
             .catch(err => {
@@ -225,43 +217,35 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[2].annotation.key).to.equal('http.path');
               expect(annotations[2].annotation.value).to.equal(urlPath);
 
-              expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[3].annotation.key).to.equal('http.host');
-              expect(annotations[3].annotation.value).to.equal(apiHost);
+              expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-              expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+              expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-              expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+              expect(annotations[5].annotation.annotationType).to.equal('ServiceName');
+              expect(annotations[5].annotation.serviceName).to.equal('weather-app');
 
-              expect(annotations[6].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[6].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[6].annotation.annotationType).to.equal('Rpc');
+              expect(annotations[6].annotation.name).to.equal('POST');
 
-              expect(annotations[7].annotation.annotationType).to.equal('Rpc');
-              expect(annotations[7].annotation.name).to.equal('POST');
+              expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[7].annotation.key).to.equal('http.path');
+              expect(annotations[7].annotation.value).to.equal(urlPath);
 
-              expect(annotations[8].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[8].annotation.key).to.equal('http.path');
-              expect(annotations[8].annotation.value).to.equal(urlPath);
+              expect(annotations[8].annotation.annotationType).to.equal('ClientSend');
 
-              expect(annotations[9].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[9].annotation.key).to.equal('http.host');
-              expect(annotations[9].annotation.value).to.equal(apiHost);
+              expect(annotations[9].annotation.annotationType).to.equal('ServerAddr');
 
-              expect(annotations[10].annotation.annotationType).to.equal('ClientSend');
+              expect(annotations[10].annotation.annotationType).to.equal('BinaryAnnotation');
+              expect(annotations[10].annotation.key).to.equal('http.status_code');
+              expect(annotations[10].annotation.value).to.equal('202');
 
-              expect(annotations[11].annotation.annotationType).to.equal('ServerAddr');
+              expect(annotations[11].annotation.annotationType).to.equal('ClientRecv');
 
               expect(annotations[12].annotation.annotationType).to.equal('BinaryAnnotation');
               expect(annotations[12].annotation.key).to.equal('http.status_code');
-              expect(annotations[12].annotation.value).to.equal('202');
+              expect(annotations[12].annotation.value).to.equal('203');
 
-              expect(annotations[13].annotation.annotationType).to.equal('ClientRecv');
-
-              expect(annotations[14].annotation.annotationType).to.equal('BinaryAnnotation');
-              expect(annotations[14].annotation.key).to.equal('http.status_code');
-              expect(annotations[14].annotation.value).to.equal('203');
-
-              expect(annotations[15].annotation.annotationType).to.equal('ServerSend');
+              expect(annotations[13].annotation.annotationType).to.equal('ServerSend');
 
               done();
             })

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -62,20 +62,16 @@ describe('wrapFetch', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.serviceName).to.equal('callee');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[5].annotation.serviceName).to.equal('callee');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
           const traceIdOnServer = data.traceId;
           expect(traceIdOnServer).to.equal(traceId);
@@ -141,23 +137,19 @@ describe('wrapFetch', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal('/');
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.serviceName).to.equal('callee');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[5].annotation.serviceName).to.equal('callee');
-
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('error');
-          expect(annotations[6].annotation.value)
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('error');
+          expect(annotations[5].annotation.value)
             .to.contain('getaddrinfo ENOTFOUND domain.invalid');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
           done();
         });
     });

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -38,8 +38,10 @@ describe('wrapFetch', () => {
       const id = tracer.createChildId();
       tracer.setId(id);
 
-      const path = `http://127.0.0.1:${this.port}/user`;
-      fetch(path, {method: 'post'})
+      const host = '127.0.0.1';
+      const urlPath = '/user';
+      const url = `http://${host}:${this.port}${urlPath}`;
+      fetch(url, {method: 'post'})
         .then(res => res.json())
         .then(data => {
           const annotations = record.args.map(args => args[0]);
@@ -57,19 +59,23 @@ describe('wrapFetch', () => {
           expect(annotations[1].annotation.name).to.equal('POST');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(path);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[4].annotation.serviceName).to.equal('callee');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.serviceName).to.equal('callee');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
           const traceIdOnServer = data.traceId;
           expect(traceIdOnServer).to.equal(traceId);
@@ -112,8 +118,9 @@ describe('wrapFetch', () => {
       const id = tracer.createChildId();
       tracer.setId(id);
 
-      const path = 'http://domain.invalid';
-      fetch(path, {method: 'post'})
+      const host = 'domain.invalid';
+      const url = `http://${host}`;
+      fetch(url, {method: 'post'})
         .then(() => expect.fail())
         .catch(() => {
           const annotations = record.args.map(args => args[0]);
@@ -131,22 +138,26 @@ describe('wrapFetch', () => {
           expect(annotations[1].annotation.name).to.equal('POST');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(path);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal('/');
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
-          expect(annotations[4].annotation.serviceName).to.equal('callee');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('error');
-          expect(annotations[5].annotation.value)
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.serviceName).to.equal('callee');
+
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('error');
+          expect(annotations[6].annotation.value)
             .to.contain('getaddrinfo ENOTFOUND domain.invalid');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
           done();
         });
     });

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -50,19 +50,15 @@ describe('hapi middleware - integration test', () => {
         expect(annotations[2].annotation.key).to.equal('http.path');
         expect(annotations[2].annotation.value).to.equal(url);
 
-        expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[3].annotation.key).to.equal('http.host');
-        expect(annotations[3].annotation.value).to.equal(null);
+        expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-        expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+        expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-        expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('202');
 
-        expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[6].annotation.key).to.equal('http.status_code');
-        expect(annotations[6].annotation.value).to.equal('202');
-
-        expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
+        expect(annotations[6].annotation.annotationType).to.equal('ServerSend');
 
         done();
       });
@@ -87,9 +83,9 @@ describe('hapi middleware - integration test', () => {
       const url = '/foo';
       server.inject({method, url}, () => {
         const annotations = record.args.map((args) => args[0]);
-        expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[6].annotation.key).to.equal('http.status_code');
-        expect(annotations[6].annotation.value).to.equal('404');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('404');
         done();
       });
     });
@@ -127,10 +123,6 @@ describe('hapi middleware - integration test', () => {
         expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
         expect(annotations[2].annotation.key).to.equal('http.path');
         expect(annotations[2].annotation.value).to.equal(path);
-
-        expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[3].annotation.key).to.equal('http.host');
-        expect(annotations[3].annotation.value).to.equal(null);
 
         done();
       });

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -47,18 +47,22 @@ describe('hapi middleware - integration test', () => {
         expect(annotations[1].annotation.name).to.equal(method);
 
         expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[2].annotation.key).to.equal('http.url');
+        expect(annotations[2].annotation.key).to.equal('http.path');
         expect(annotations[2].annotation.value).to.equal(url);
 
-        expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+        expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[3].annotation.key).to.equal('http.host');
+        expect(annotations[3].annotation.value).to.equal(null);
 
-        expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[5].annotation.key).to.equal('http.status_code');
-        expect(annotations[5].annotation.value).to.equal('202');
+        expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
-        expect(annotations[6].annotation.annotationType).to.equal('ServerSend');
+        expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[6].annotation.key).to.equal('http.status_code');
+        expect(annotations[6].annotation.value).to.equal('202');
+
+        expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
 
         done();
       });
@@ -83,9 +87,9 @@ describe('hapi middleware - integration test', () => {
       const url = '/foo';
       server.inject({method, url}, () => {
         const annotations = record.args.map((args) => args[0]);
-        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[5].annotation.key).to.equal('http.status_code');
-        expect(annotations[5].annotation.value).to.equal('404');
+        expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[6].annotation.key).to.equal('http.status_code');
+        expect(annotations[6].annotation.value).to.equal('404');
         done();
       });
     });
@@ -115,13 +119,18 @@ describe('hapi middleware - integration test', () => {
       });
 
       const method = 'GET';
-      const url = '/foo?abc=123';
+      const path = '/foo';
+      const url = `${path}?abc=123`;
       server.inject({method, url}, () => {
         const annotations = record.args.map(args => args[0]);
 
         expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[2].annotation.key).to.equal('http.url');
-        expect(annotations[2].annotation.value).to.equal(url);
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(path);
+
+        expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[3].annotation.key).to.equal('http.host');
+        expect(annotations[3].annotation.value).to.equal(null);
 
         done();
       });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -55,19 +55,15 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(apiHost);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -98,19 +94,15 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(apiHost);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -141,19 +133,15 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(apiHost);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -185,19 +173,15 @@ describe('request instrumentation - integration test', () => {
             expect(annotations[2].annotation.key).to.equal('http.path');
             expect(annotations[2].annotation.value).to.equal(urlPath);
 
-            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[3].annotation.key).to.equal('http.host');
-            expect(annotations[3].annotation.value).to.equal(apiHost);
+            expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-            expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+            expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-            expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+            expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[5].annotation.key).to.equal('http.status_code');
+            expect(annotations[5].annotation.value).to.equal('202');
 
-            expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[6].annotation.key).to.equal('http.status_code');
-            expect(annotations[6].annotation.value).to.equal('202');
-
-            expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+            expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
             done();
           }
         });
@@ -229,19 +213,15 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(apiHost);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
-
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -273,21 +253,17 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(apiHost);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('http.status_code');
+          expect(annotations[5].annotation.value).to.equal('404');
 
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('404');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
-
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
 
           done();
         });
@@ -319,22 +295,18 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal('/');
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
-
-          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('error');
-          expect(annotations[6].annotation.value)
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('error');
+          expect(annotations[5].annotation.value)
             .to.contain('Error: getaddrinfo ENOTFOUND bad.invalid.url bad.invalid.url:80');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
           done();
         });
       });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -34,8 +34,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        const urlPath = '/weather';
+        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest.get(url, () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -50,18 +52,22 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(apiHost);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -71,8 +77,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        const urlPath = '/weather';
+        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest(url, () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -87,18 +95,22 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(apiHost);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -108,8 +120,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        const urlPath = '/weather';
+        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({url}, () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -124,18 +138,22 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(apiHost);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -145,8 +163,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        const urlPath = '/weather';
+        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({
           url, callback: () => {
             const annotations = record.args.map(args => args[0]);
@@ -162,18 +182,22 @@ describe('request instrumentation - integration test', () => {
             expect(annotations[1].annotation.name).to.equal('GET');
 
             expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[2].annotation.key).to.equal('http.url');
-            expect(annotations[2].annotation.value).to.equal(url);
+            expect(annotations[2].annotation.key).to.equal('http.path');
+            expect(annotations[2].annotation.value).to.equal(urlPath);
 
-            expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+            expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[3].annotation.key).to.equal('http.host');
+            expect(annotations[3].annotation.value).to.equal(apiHost);
 
-            expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+            expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-            expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-            expect(annotations[5].annotation.key).to.equal('http.status_code');
-            expect(annotations[5].annotation.value).to.equal('202');
+            expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-            expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+            expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+            expect(annotations[6].annotation.key).to.equal('http.status_code');
+            expect(annotations[6].annotation.value).to.equal('202');
+
+            expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
             done();
           }
         });
@@ -184,8 +208,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/weather?index=10&count=300`;
+        const urlPath = '/weather';
+        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({url}).on('response', () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -200,18 +226,22 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(apiHost);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
+
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
           done();
         });
       });
@@ -222,8 +252,10 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
+        const apiHost = '127.0.0.1';
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = `http://127.0.0.1:${apiPort}/doesNotExist`;
+        const urlPath = '/doesNotExist';
+        const url = `http://${apiHost}:${apiPort}${urlPath}`;
         zipkinRequest({url, timeout: 100}).on('response', () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -238,20 +270,24 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(apiHost);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('404');
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('404');
 
-          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+
+          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
 
           done();
         });
@@ -264,7 +300,8 @@ describe('request instrumentation - integration test', () => {
     tracer.scoped(() => {
       api.listen(0, () => {
         const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
-        const url = 'http://bad.invalid.url';
+        const host = 'bad.invalid.url';
+        const url = `http://${host}`;
         zipkinRequest({url, timeout: 100}).on('error', () => {
           const annotations = record.args.map(args => args[0]);
           const initialTraceId = annotations[0].traceId.traceId;
@@ -279,21 +316,25 @@ describe('request instrumentation - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('GET');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal('/');
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('error');
-          expect(annotations[5].annotation.value)
+          expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+
+          expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[6].annotation.key).to.equal('error');
+          expect(annotations[6].annotation.value)
             .to.contain('Error: getaddrinfo ENOTFOUND bad.invalid.url bad.invalid.url:80');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
+          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
           done();
         });
       });

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -58,23 +58,19 @@ describe('restify middleware - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('message');
+          expect(annotations[5].annotation.value).to.equal('hello from within app');
 
           expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('message');
-          expect(annotations[6].annotation.value).to.equal('hello from within app');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('202');
 
-          expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[7].annotation.key).to.equal('http.status_code');
-          expect(annotations[7].annotation.value).to.equal('202');
-
-          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+          expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
 
           done();
         })
@@ -189,27 +185,23 @@ describe('restify middleware - integration test', () => {
           expect(annotations[2].annotation.key).to.equal('http.path');
           expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[3].annotation.key).to.equal('http.host');
-          expect(annotations[3].annotation.value).to.equal(host);
+          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[5].annotation.key).to.equal('message');
+          expect(annotations[5].annotation.value).to.equal('testing error annotation recording');
 
           expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('message');
-          expect(annotations[6].annotation.value).to.equal('testing error annotation recording');
+          expect(annotations[6].annotation.key).to.equal('http.status_code');
+          expect(annotations[6].annotation.value).to.equal('404');
 
           expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[7].annotation.key).to.equal('http.status_code');
+          expect(annotations[7].annotation.key).to.equal('error');
           expect(annotations[7].annotation.value).to.equal('404');
 
-          expect(annotations[8].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[8].annotation.key).to.equal('error');
-          expect(annotations[8].annotation.value).to.equal('404');
-
-          expect(annotations[9].annotation.annotationType).to.equal('ServerSend');
+          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
 
           done();
         })

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -30,7 +30,9 @@ describe('restify middleware - integration test', () => {
       });
       const server = app.listen(0, () => {
         const port = server.address().port;
-        const url = `http://127.0.0.1:${port}/foo`;
+        const host = '127.0.0.1';
+        const urlPath = '/foo';
+        const url = `http://${host}:${port}${urlPath}`;
         fetch(url, {
           method: 'post',
           headers: {
@@ -53,22 +55,27 @@ describe('restify middleware - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('POST');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('message');
-          expect(annotations[5].annotation.value).to.equal('hello from within app');
+          expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
           expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('202');
+          expect(annotations[6].annotation.key).to.equal('message');
+          expect(annotations[6].annotation.value).to.equal('hello from within app');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
+          expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[7].annotation.key).to.equal('http.status_code');
+          expect(annotations[7].annotation.value).to.equal('202');
+
+          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+
           done();
         })
         .catch(err => {
@@ -154,7 +161,9 @@ describe('restify middleware - integration test', () => {
       });
       const server = app.listen(0, () => {
         const port = server.address().port;
-        const url = `http://127.0.0.1:${port}/foo`;
+        const host = '127.0.0.1';
+        const urlPath = '/foo';
+        const url = `http://${host}:${port}${urlPath}`;
         fetch(url, {
           method: 'post',
           headers: {
@@ -177,26 +186,30 @@ describe('restify middleware - integration test', () => {
           expect(annotations[1].annotation.name).to.equal('POST');
 
           expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.url');
-          expect(annotations[2].annotation.value).to.equal(url);
+          expect(annotations[2].annotation.key).to.equal('http.path');
+          expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+          expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[3].annotation.key).to.equal('http.host');
+          expect(annotations[3].annotation.value).to.equal(host);
 
-          expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+          expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('message');
-          expect(annotations[5].annotation.value).to.equal('testing error annotation recording');
+          expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
 
           expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[6].annotation.key).to.equal('http.status_code');
-          expect(annotations[6].annotation.value).to.equal('404');
+          expect(annotations[6].annotation.key).to.equal('message');
+          expect(annotations[6].annotation.value).to.equal('testing error annotation recording');
 
           expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[7].annotation.key).to.equal('error');
+          expect(annotations[7].annotation.key).to.equal('http.status_code');
           expect(annotations[7].annotation.value).to.equal('404');
 
-          expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+          expect(annotations[8].annotation.annotationType).to.equal('BinaryAnnotation');
+          expect(annotations[8].annotation.key).to.equal('error');
+          expect(annotations[8].annotation.value).to.equal('404');
+
+          expect(annotations[9].annotation.annotationType).to.equal('ServerSend');
 
           done();
         })

--- a/packages/zipkin/src/index.js
+++ b/packages/zipkin/src/index.js
@@ -19,6 +19,7 @@ const Instrumentation = require('./instrumentation');
 
 const model = require('./model');
 const jsonEncoder = require('./jsonEncoder');
+const parseRequestUrl = require('./parseUrl');
 
 module.exports = {
   Tracer,
@@ -35,5 +36,6 @@ module.exports = {
   Request,
   Instrumentation,
   model,
-  jsonEncoder
+  jsonEncoder,
+  parseRequestUrl
 };

--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -20,7 +20,7 @@ class HttpClientInstrumentation {
   recordRequest(request, url, method) {
     this.tracer.setId(this.tracer.createChildId());
     const traceId = this.tracer.id;
-    const { path, host } = parseRequestUrl(url);
+    const {path, host} = parseRequestUrl(url);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());

--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -20,12 +20,11 @@ class HttpClientInstrumentation {
   recordRequest(request, url, method) {
     this.tracer.setId(this.tracer.createChildId());
     const traceId = this.tracer.id;
-    const {path, host} = parseRequestUrl(url);
+    const {path} = parseRequestUrl(url);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
-    this.tracer.recordBinary('http.host', host);
     this.tracer.recordAnnotation(new Annotation.ClientSend());
     if (this.remoteServiceName) {
       // TODO: can we get the host and port of the http connection?

--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -1,5 +1,6 @@
 const Annotation = require('../annotation');
 const Request = require('../request');
+const parseRequestUrl = require('../parseUrl');
 
 function requiredArg(name) {
   throw new Error(`HttpClientInstrumentation: Missing required argument ${name}.`);
@@ -19,10 +20,12 @@ class HttpClientInstrumentation {
   recordRequest(request, url, method) {
     this.tracer.setId(this.tracer.createChildId());
     const traceId = this.tracer.id;
+    const { path, host } = parseRequestUrl(url);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
-    this.tracer.recordBinary('http.url', url);
+    this.tracer.recordBinary('http.path', path);
+    this.tracer.recordBinary('http.host', host);
     this.tracer.recordAnnotation(new Annotation.ClientSend());
     if (this.remoteServiceName) {
       // TODO: can we get the host and port of the http connection?

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -71,12 +71,11 @@ class HttpServerInstrumentation {
   recordRequest(method, requestUrl, readHeader) {
     this._createIdFromHeaders(readHeader).ifPresent(id => this.tracer.setId(id));
     const id = this.tracer.id;
-    const {path, host} = parseRequestUrl(requestUrl);
+    const {path} = parseRequestUrl(requestUrl);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
-    this.tracer.recordBinary('http.host', host);
     this.tracer.recordAnnotation(new Annotation.ServerRecv());
     this.tracer.recordAnnotation(new Annotation.LocalAddr({port: this.port}));
 

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -2,6 +2,7 @@ const Header = require('../httpHeaders');
 const {Some, None} = require('../option');
 const TraceId = require('../tracer/TraceId');
 const Annotation = require('../annotation');
+const parseRequestUrl = require('../parseUrl');
 
 function stringToBoolean(str) {
   return str === '1' || str === 'true';
@@ -70,10 +71,12 @@ class HttpServerInstrumentation {
   recordRequest(method, requestUrl, readHeader) {
     this._createIdFromHeaders(readHeader).ifPresent(id => this.tracer.setId(id));
     const id = this.tracer.id;
+    const { path, host } = parseRequestUrl(requestUrl);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
-    this.tracer.recordBinary('http.url', requestUrl);
+    this.tracer.recordBinary('http.path', path);
+    this.tracer.recordBinary('http.host', host);
     this.tracer.recordAnnotation(new Annotation.ServerRecv());
     this.tracer.recordAnnotation(new Annotation.LocalAddr({port: this.port}));
 

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -71,7 +71,7 @@ class HttpServerInstrumentation {
   recordRequest(method, requestUrl, readHeader) {
     this._createIdFromHeaders(readHeader).ifPresent(id => this.tracer.setId(id));
     const id = this.tracer.id;
-    const { path, host } = parseRequestUrl(requestUrl);
+    const {path, host} = parseRequestUrl(requestUrl);
 
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());

--- a/packages/zipkin/src/parseUrl.js
+++ b/packages/zipkin/src/parseUrl.js
@@ -1,0 +1,12 @@
+const url = require('url');
+
+function parseRequestUrl(requestUrl) {
+  const parsed = url.parse(requestUrl);
+
+  return {
+    host: parsed.hostname,
+    path: parsed.pathname
+  };
+}
+
+module.exports = parseRequestUrl;

--- a/packages/zipkin/test/httpClientInstrumentation.test.js
+++ b/packages/zipkin/test/httpClientInstrumentation.test.js
@@ -38,20 +38,16 @@ describe('Http Client Instrumentation', () => {
     expect(annotations[2].annotation.key).to.equal('http.path');
     expect(annotations[2].annotation.value).to.equal(urlPath);
 
-    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[3].annotation.key).to.equal('http.host');
-    expect(annotations[3].annotation.value).to.equal(host);
+    expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-    expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
+    expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+    expect(annotations[4].annotation.serviceName).to.equal('weather-forecast-service');
 
-    expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
-    expect(annotations[5].annotation.serviceName).to.equal('weather-forecast-service');
+    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[5].annotation.key).to.equal('http.status_code');
+    expect(annotations[5].annotation.value).to.equal('202');
 
-    expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[6].annotation.key).to.equal('http.status_code');
-    expect(annotations[6].annotation.value).to.equal('202');
-
-    expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+    expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
   });
 
   it('should record an error', () => {
@@ -75,8 +71,8 @@ describe('Http Client Instrumentation', () => {
       .to.equal(initialTraceId).and
       .to.have.lengthOf(16));
 
-    expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[6].annotation.key).to.equal('error');
-    expect(annotations[6].annotation.value).to.equal('Error: nasty error');
+    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[5].annotation.key).to.equal('error');
+    expect(annotations[5].annotation.value).to.equal('Error: nasty error');
   });
 });

--- a/packages/zipkin/test/httpClientInstrumentation.test.js
+++ b/packages/zipkin/test/httpClientInstrumentation.test.js
@@ -14,7 +14,10 @@ describe('Http Client Instrumentation', () => {
       serviceName: 'weather-app',
       remoteServiceName: 'weather-forecast-service'});
 
-    const url = 'http://127.0.0.1:80/weather?index=10&count=300';
+    const port = '80';
+    const host = '127.0.0.1';
+    const urlPath = '/weather';
+    const url = `http://${host}:${port}${urlPath}?index=10&count=300`;
     tracer.scoped(() => {
       instrumentation.recordRequest({}, url, 'GET');
       instrumentation.recordResponse(tracer.id, '202');
@@ -32,19 +35,23 @@ describe('Http Client Instrumentation', () => {
     expect(annotations[1].annotation.name).to.equal('GET');
 
     expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[2].annotation.key).to.equal('http.url');
-    expect(annotations[2].annotation.value).to.equal(url);
+    expect(annotations[2].annotation.key).to.equal('http.path');
+    expect(annotations[2].annotation.value).to.equal(urlPath);
 
-    expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[3].annotation.key).to.equal('http.host');
+    expect(annotations[3].annotation.value).to.equal(host);
 
-    expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
-    expect(annotations[4].annotation.serviceName).to.equal('weather-forecast-service');
+    expect(annotations[4].annotation.annotationType).to.equal('ClientSend');
 
-    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[5].annotation.key).to.equal('http.status_code');
-    expect(annotations[5].annotation.value).to.equal('202');
+    expect(annotations[5].annotation.annotationType).to.equal('ServerAddr');
+    expect(annotations[5].annotation.serviceName).to.equal('weather-forecast-service');
 
-    expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+    expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[6].annotation.key).to.equal('http.status_code');
+    expect(annotations[6].annotation.value).to.equal('202');
+
+    expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
   });
 
   it('should record an error', () => {
@@ -68,8 +75,8 @@ describe('Http Client Instrumentation', () => {
       .to.equal(initialTraceId).and
       .to.have.lengthOf(16));
 
-    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[5].annotation.key).to.equal('error');
-    expect(annotations[5].annotation.value).to.equal('Error: nasty error');
+    expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[6].annotation.key).to.equal('error');
+    expect(annotations[6].annotation.value).to.equal('Error: nasty error');
   });
 });

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -39,23 +39,19 @@ describe('Http Server Instrumentation', () => {
     expect(annotations[2].annotation.key).to.equal('http.path');
     expect(annotations[2].annotation.value).to.equal(url);
 
-    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[3].annotation.key).to.equal('http.host');
-    expect(annotations[3].annotation.value).to.equal(null);
+    expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-    expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+    expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-    expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[5].annotation.key).to.equal('message');
+    expect(annotations[5].annotation.value).to.equal('hello from within app');
 
     expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[6].annotation.key).to.equal('message');
-    expect(annotations[6].annotation.value).to.equal('hello from within app');
+    expect(annotations[6].annotation.key).to.equal('http.status_code');
+    expect(annotations[6].annotation.value).to.equal('202');
 
-    expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[7].annotation.key).to.equal('http.status_code');
-    expect(annotations[7].annotation.value).to.equal('202');
-
-    expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+    expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
   });
 
   it('should receive trace info from the client', () => {
@@ -94,23 +90,19 @@ describe('Http Server Instrumentation', () => {
     expect(annotations[2].annotation.key).to.equal('http.path');
     expect(annotations[2].annotation.value).to.equal('/');
 
-    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[3].annotation.key).to.equal('http.host');
-    expect(annotations[3].annotation.value).to.equal(host);
+    expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
 
-    expect(annotations[4].annotation.annotationType).to.equal('ServerRecv');
+    expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
-    expect(annotations[5].annotation.annotationType).to.equal('LocalAddr');
+    expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+    expect(annotations[5].annotation.key).to.equal('message');
+    expect(annotations[5].annotation.value).to.equal('hello from within app');
 
     expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[6].annotation.key).to.equal('message');
-    expect(annotations[6].annotation.value).to.equal('hello from within app');
+    expect(annotations[6].annotation.key).to.equal('http.status_code');
+    expect(annotations[6].annotation.value).to.equal('202');
 
-    expect(annotations[7].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[7].annotation.key).to.equal('http.status_code');
-    expect(annotations[7].annotation.value).to.equal('202');
-
-    expect(annotations[8].annotation.annotationType).to.equal('ServerSend');
+    expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
   });
 
   it('should properly report the URL with a query string', () => {
@@ -134,10 +126,6 @@ describe('Http Server Instrumentation', () => {
     expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
     expect(annotations[2].annotation.key).to.equal('http.path');
     expect(annotations[2].annotation.value).to.equal(urlPath);
-
-    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[3].annotation.key).to.equal('http.host');
-    expect(annotations[3].annotation.value).to.equal(host);
   });
 
   it('should accept a 128bit X-B3-TraceId', () => {


### PR DESCRIPTION
At the moment, Zipkin JS is including `http.url` as annotation including all query strings. This has some privacy issues (e.g. passing e-mails or tokens in query parameters) so most zipkin instrumentations include the `http.path` instead.

Ping @jcchavezs @adriancole 