### PR TITLE
change addZipkinHeaders method to not modify the IncomingMessage object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 lerna-debug.log
 yarn-error.log
 package-lock.json
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ npm-debug.log
 lerna-debug.log
 yarn-error.log
 package-lock.json
-.vscode/

--- a/packages/zipkin/src/request.js
+++ b/packages/zipkin/src/request.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const HttpHeaders = require('./httpHeaders');
 
 function appendZipkinHeaders(req, traceId) {
@@ -16,8 +17,9 @@ function appendZipkinHeaders(req, traceId) {
 }
 
 function addZipkinHeaders(req, traceId) {
-  const headers = appendZipkinHeaders(req, traceId);
-  return Object.assign({}, req, {headers});
+  req.headers = appendZipkinHeaders(req, traceId);
+
+  return req;
 }
 
 module.exports = {

--- a/packages/zipkin/test/request.test.js
+++ b/packages/zipkin/test/request.test.js
@@ -2,8 +2,22 @@ const Request = require('../src/request.js');
 const HttpHeaders = require('../src/httpHeaders');
 const {Some} = require('../src/option');
 const TraceId = require('../src/tracer/TraceId');
+const {IncomingMessage} = require('http');
 
 describe('Request', () => {
+  it('should not change an object\'s existing methods', () => {
+    const traceId = new TraceId({
+      traceId: new Some('48485a3953bb6124'),
+      spanId: '48485a3953bb6124'
+    });
+
+    const testRequest = new IncomingMessage();
+    const resultRequest = Request.addZipkinHeaders(testRequest, traceId);
+
+    expect(resultRequest.on).to.exist; // eslint-disable-line no-unused-expressions
+    expect(resultRequest.on).to.be.a('function');
+  });
+
   it('should add trace/span and ignore parent span/sampled headers if they do not exist', () => {
     const traceId = new TraceId({
       traceId: new Some('48485a3953bb6124'),


### PR DESCRIPTION
An incoming request is actually an [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object.
This fixes any attempt to use the on() event method after zipkin modifies it's headers.