### PR TITLE
Relax response code expectation to allow 200s

### DIFF
--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -60,7 +60,7 @@ class HttpLogger extends EventEmitter {
         headers: self.headers,
         timeout: self.timeout,
       }).then((response) => {
-        if (response.status !== 202) {
+        if (response.status !== 202 && response.status !== 200) {
           const err = 'Unexpected response while sending Zipkin data, status:' +
             `${response.status}, body: ${postBody}`;
 

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -66,6 +66,8 @@ class HttpLogger extends EventEmitter {
 
           if (self.errorListenerSet) this.emit('error', new Error(err));
           else console.error(err);
+        } else {
+          this.emit('success', response);
         }
       }).catch((error) => {
         const err = `Error sending Zipkin data ${error}`;


### PR DESCRIPTION
We have mimicked the Zipkin API but don't use 202s since they are not appropriate in our case.