### PR TITLE
fix: kipkin ConsoleRecorder constructor does not match ts type

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -269,7 +269,7 @@ declare namespace zipkin {
   }
 
   class ConsoleRecorder implements Recorder {
-    constructor(args?: { logger?: Logger });
+    constructor(logger?: (message: string) => void);
     record: (rec: Record) => void;
   }
 


### PR DESCRIPTION
I adapted the Typescript definition file to match the implementation. I didn't change the implementation because I don't know what it's the intention of the developers. `BatchRecorder` receives a `Logger` type.
https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/src/console-recorder.js#L8
vs
https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/src/batch-recorder.js#L59