### PR TITLE
Fixes sampling flags extraction.

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -36,6 +36,7 @@ declare namespace zipkin {
     scoped<V>(callback: () => V): V;
     local<V>(name: string, callback: () => V): V;
     createRootId(): TraceId;
+    createIdFromSamplingFlags(isSampled: option.IOption, isDebug: number): TraceId
     createChildId(): TraceId;
     letId<V>(traceId: TraceId, callback: () => V): V;
     setId(traceId: TraceId): void;

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -35,8 +35,7 @@ declare namespace zipkin {
 
     scoped<V>(callback: () => V): V;
     local<V>(name: string, callback: () => V): V;
-    createRootId(): TraceId;
-    createIdFromSamplingFlags(isSampled: option.IOption, isDebug: number): TraceId
+    createRootId(isSampled?: option.IOption, isDebug?: boolean): TraceId;
     createChildId(): TraceId;
     letId<V>(traceId: TraceId, callback: () => V): V;
     setId(traceId: TraceId): void;

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -59,7 +59,7 @@ class HttpServerInstrumentation {
         const sampled = readHeader(Header.Sampled) === None ?
               None : readHeader(Header.Sampled).map(stringToBoolean);
         const flags = readHeader(Header.Flags).flatMap(stringToIntOption).getOrElse(0);
-        return new Some(this.tracer.createIdFromSamplingFlags(sampled, flags));
+        return new Some(this.tracer.createRootId(sampled, flags === 1));
       } else {
         return new Some(this.tracer.createRootId());
       }

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -56,16 +56,10 @@ class HttpServerInstrumentation {
       });
     } else {
       if (readHeader(Header.Flags) !== None || readHeader(Header.Sampled) !== None) {
-        const currentId = this.tracer.id;
-        const idWithFlags = new TraceId({
-          traceId: new Some(currentId.traceId),
-          parentId: None,
-          spanId: new Some(currentId.spanId),
-          sampled: readHeader(Header.Sampled) === None ?
-              currentId.sampled : readHeader(Header.Sampled).map(stringToBoolean),
-          flags: readHeader(Header.Flags).flatMap(stringToIntOption).getOrElse(0),
-        });
-        return new Some(idWithFlags);
+        const sampled = readHeader(Header.Sampled) === None ?
+              None : readHeader(Header.Sampled).map(stringToBoolean);
+        const flags = readHeader(Header.Flags).flatMap(stringToIntOption).getOrElse(0);
+        return new Some(this.tracer.createIdFromSamplingFlags(sampled, flags));
       } else {
         return new Some(this.tracer.createRootId());
       }

--- a/packages/zipkin/src/option.js
+++ b/packages/zipkin/src/option.js
@@ -81,6 +81,12 @@ function verifyIsOptional(data) {
   }
 }
 
+function verifyIsNotOptional(data) {
+  if (data != null && isOptional(data)) {
+    throw new Error(`Error: data (${data}) is an Option!`);
+  }
+}
+
 function fromNullable(nullable) {
   if (nullable != null) {
     return new Some(nullable);
@@ -92,4 +98,5 @@ function fromNullable(nullable) {
 module.exports.Some = Some;
 module.exports.None = None;
 module.exports.verifyIsOptional = verifyIsOptional;
+module.exports.verifyIsNotOptional = verifyIsNotOptional;
 module.exports.fromNullable = fromNullable;

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -1,10 +1,11 @@
-const {Some, None, verifyIsOptional} = require('../option');
+const {Some, None, verifyIsOptional, verifyIsNotOptional} = require('../option');
 
 class TraceId {
   constructor(params) {
     const {traceId = None, parentId = None, spanId, sampled = None, flags = 0} = params;
     verifyIsOptional(traceId);
     verifyIsOptional(parentId);
+    verifyIsNotOptional(spanId);
     verifyIsOptional(sampled);
     this._traceId = traceId;
     this._parentId = parentId;

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -51,7 +51,7 @@ class Tracer {
     return this._ctxImpl.letContext(id, callback);
   }
 
-  createRootId() {
+  createRootId(isSampled = None, isDebug = false) {
     const rootSpanId = randomTraceId();
     const traceId = this.traceId128Bit
       ? new Some(randomTraceId() + rootSpanId)
@@ -60,29 +60,14 @@ class Tracer {
       traceId,
       parentId: None,
       spanId: rootSpanId,
-      sampled: None,
-      flags: 0
-    });
-    id._sampled = this.sampler.shouldSample(id);
-    return id;
-  }
-
-  createIdFromSamplingFlags(isSampled, isDebug) {
-    const rootSpanId = randomTraceId();
-    const traceId = this.traceId128Bit
-            ? new Some(randomTraceId() + rootSpanId)
-            : None;
-    const id = new TraceId({
-      traceId,
-      parentId: None,
-      spanId: rootSpanId,
       sampled: isSampled,
-      flags: isDebug
+      flags: isDebug ? 1 : 0
     });
 
     if (isSampled === None) {
       id._sampled = this.sampler.shouldSample(id);
     }
+
     return id;
   }
 

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -170,6 +170,9 @@ describe('Http Server Instrumentation', () => {
       const annotations = record.args.map(args => args[0]);
 
       if (hasAnnotations === true) {
+        annotations.forEach(ann => expect(ann.traceId.traceId).to.not.be.empty);
+        annotations.forEach(ann => expect(ann.traceId.spanId).to.not.be.empty);
+
         expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
         expect(annotations[0].annotation.serviceName).to.equal('service-a');
 
@@ -200,7 +203,7 @@ describe('Http Server Instrumentation', () => {
     });
   });
 
-  it('should properly report the URL with a query string', () => {
+  it('should properly report the path excluding the query string', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();


### PR DESCRIPTION
This PR fixes a bug in the sampling flags extraction as we were providing a `optional` value in https://github.com/openzipkin/zipkin-js/pull/247/files#diff-5afae8abcf08e9bdf241cbb7eed71aaaR8

Also it fixes a problem because the new context was created on top of the any existing one by using the https://github.com/openzipkin/zipkin-js/pull/247/files#diff-aa30be809cfe81ece1c873af6639ef3cR70