### PR TITLE
Upgrades lerna to avoid npm deprecations due to prepublish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
-    "lerna": "^2.1.2",
+    "lerna": "^2.11.0",
     "yarn": "^1.3.2"
   },
   "scripts": {


### PR DESCRIPTION
While publishing a new release for `zipkin-js` we had some issues with deprecations, notably from `npm prepublish`. Upgrading lerna solves those issues as it stop using `prepublish` and uses `prepare` instead.

Ping @adriancole @eirslett 