### PR TITLE
Removing require.call

### DIFF
--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -4,7 +4,7 @@ const globalFetch =
   (typeof global !== 'undefined' && global.fetch);
 
 // eslint-disable-next-line global-require
-const fetch = globalFetch || require.call(null, 'node-fetch');
+const fetch = globalFetch || require('node-fetch');
 
 const {
   jsonEncoder: {JSON_V1}

--- a/packages/zipkin/package.json
+++ b/packages/zipkin/package.json
@@ -14,8 +14,7 @@
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
     "base64-js": "^1.1.2",
-    "is-promise": "^2.1.0",
-    "network-address": "^1.1.0"
+    "is-promise": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/zipkin/package.json
+++ b/packages/zipkin/package.json
@@ -14,7 +14,8 @@
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
     "base64-js": "^1.1.2",
-    "is-promise": "^2.1.0"
+    "is-promise": "^2.1.0",
+    "network-address": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/zipkin/src/InetAddress.js
+++ b/packages/zipkin/src/InetAddress.js
@@ -38,7 +38,7 @@ InetAddress.getLocalAddress = function getLocalAddress() {
   }
 
   // eslint-disable-next-line global-require
-  const networkAddress = require.call(null, 'network-address');
+  const networkAddress = require('network-address');
   return new InetAddress(networkAddress.ipv4());
 };
 

--- a/packages/zipkin/src/InetAddress.js
+++ b/packages/zipkin/src/InetAddress.js
@@ -38,7 +38,7 @@ InetAddress.getLocalAddress = function getLocalAddress() {
   }
 
   // eslint-disable-next-line global-require
-  const networkAddress = require('./network');
+  const networkAddress = require('network-address');
   return new InetAddress(networkAddress.ipv4());
 };
 

--- a/packages/zipkin/src/InetAddress.js
+++ b/packages/zipkin/src/InetAddress.js
@@ -38,7 +38,7 @@ InetAddress.getLocalAddress = function getLocalAddress() {
   }
 
   // eslint-disable-next-line global-require
-  const networkAddress = require('network-address');
+  const networkAddress = require('./network');
   return new InetAddress(networkAddress.ipv4());
 };
 

--- a/packages/zipkin/src/network.js
+++ b/packages/zipkin/src/network.js
@@ -1,23 +1,39 @@
-const os = require('os');
+var os = require('os')
 
-function pickInterface(interfaces, family) {
+function pickInterface (interfaces, family) {
   /*eslint-disable */
-  for (const i in interfaces) {
+  for (var i in interfaces) {
     /*eslint-enable */
-    for (let j = interfaces[i].length - 1; j >= 0; j--) {
-      const face = interfaces[i][j];
-      const reachable = family === 'IPv4' || face.scopeid === 0;
-      if (!face.internal && face.family === family && reachable) return face.address;
+    for (var j = interfaces[i].length - 1; j >= 0; j--) {
+      var face = interfaces[i][j]
+      var reachable = family === 'IPv4' || face.scopeid === 0
+      if (!face.internal && face.family === family && reachable) return face.address
     }
   }
-  return family === 'IPv4' ? '127.0.0.1' : '::1';
+  return family === 'IPv4' ? '127.0.0.1' : '::1'
 }
 
-function ipv4() {
-  const interfaces = os.networkInterfaces();
-  return pickInterface(interfaces, 'IPv4');
+function reduceInterfaces (interfaces, iface) {
+  var ifaces = {}
+  for (var i in interfaces) {
+    if (i === iface) ifaces[i] = interfaces[i]
+  }
+  return ifaces
 }
 
-module.exports = {
-  ipv4
-};
+function ipv4 (iface) {
+  var interfaces = os.networkInterfaces()
+  if (iface) interfaces = reduceInterfaces(interfaces, iface)
+  return pickInterface(interfaces, 'IPv4')
+}
+
+function ipv6 (iface) {
+  var interfaces = os.networkInterfaces()
+  if (iface) interfaces = reduceInterfaces(interfaces, iface)
+  return pickInterface(interfaces, 'IPv6')
+}
+
+ipv4.ipv4 = ipv4
+ipv4.ipv6 = ipv6
+
+module.exports = ipv4

--- a/packages/zipkin/src/network.js
+++ b/packages/zipkin/src/network.js
@@ -1,0 +1,21 @@
+const os = require('os');
+
+function pickInterface(interfaces, family) {
+  for (const i in interfaces) {
+    for (let j = interfaces[i].length - 1; j >= 0; j--) {
+      const face = interfaces[i][j];
+      const reachable = family === 'IPv4' || face.scopeid === 0;
+      if (!face.internal && face.family === family && reachable) return face.address;
+    }
+  }
+  return family === 'IPv4' ? '127.0.0.1' : '::1';
+}
+
+function ipv4() {
+  const interfaces = os.networkInterfaces();
+  return pickInterface(interfaces, 'IPv4');
+}
+
+module.exports = {
+  ipv4
+};

--- a/packages/zipkin/src/network.js
+++ b/packages/zipkin/src/network.js
@@ -1,39 +1,41 @@
-var os = require('os')
+const os = require('os');
 
-function pickInterface (interfaces, family) {
+function pickInterface(interfaces, family) {
   /*eslint-disable */
-  for (var i in interfaces) {
+  for (const i in interfaces) {
     /*eslint-enable */
-    for (var j = interfaces[i].length - 1; j >= 0; j--) {
-      var face = interfaces[i][j]
-      var reachable = family === 'IPv4' || face.scopeid === 0
-      if (!face.internal && face.family === family && reachable) return face.address
+    for (let j = interfaces[i].length - 1; j >= 0; j--) {
+      const face = interfaces[i][j];
+      const reachable = family === 'IPv4' || face.scopeid === 0;
+      if (!face.internal && face.family === family && reachable) return face.address;
     }
   }
-  return family === 'IPv4' ? '127.0.0.1' : '::1'
+  return family === 'IPv4' ? '127.0.0.1' : '::1';
 }
 
-function reduceInterfaces (interfaces, iface) {
-  var ifaces = {}
-  for (var i in interfaces) {
-    if (i === iface) ifaces[i] = interfaces[i]
+function reduceInterfaces(interfaces, iface) {
+  const ifaces = {};
+  /*eslint-disable */
+  for (const i in interfaces) {
+    /*eslint-enable */
+    if (i === iface) ifaces[i] = interfaces[i];
   }
-  return ifaces
+  return ifaces;
 }
 
-function ipv4 (iface) {
-  var interfaces = os.networkInterfaces()
-  if (iface) interfaces = reduceInterfaces(interfaces, iface)
-  return pickInterface(interfaces, 'IPv4')
+function ipv4(iface) {
+  let interfaces = os.networkInterfaces();
+  if (iface) interfaces = reduceInterfaces(interfaces, iface);
+  return pickInterface(interfaces, 'IPv4');
 }
 
-function ipv6 (iface) {
-  var interfaces = os.networkInterfaces()
-  if (iface) interfaces = reduceInterfaces(interfaces, iface)
-  return pickInterface(interfaces, 'IPv6')
+function ipv6(iface) {
+  let interfaces = os.networkInterfaces();
+  if (iface) interfaces = reduceInterfaces(interfaces, iface);
+  return pickInterface(interfaces, 'IPv6');
 }
 
-ipv4.ipv4 = ipv4
-ipv4.ipv6 = ipv6
+ipv4.ipv4 = ipv4;
+ipv4.ipv6 = ipv6;
 
-module.exports = ipv4
+module.exports = ipv4;

--- a/packages/zipkin/src/network.js
+++ b/packages/zipkin/src/network.js
@@ -1,7 +1,9 @@
 const os = require('os');
 
 function pickInterface(interfaces, family) {
+  /*eslint-disable */
   for (const i in interfaces) {
+    /*eslint-enable */
     for (let j = interfaces[i].length - 1; j >= 0; j--) {
       const face = interfaces[i][j];
       const reachable = family === 'IPv4' || face.scopeid === 0;

--- a/packages/zipkin/src/network.js
+++ b/packages/zipkin/src/network.js
@@ -1,5 +1,6 @@
 const os = require('os');
 
+
 function pickInterface(interfaces, family) {
   /*eslint-disable */
   for (const i in interfaces) {


### PR DESCRIPTION
Since require.call it's making webpack give some warnings, I'm removing it and using only require. The change was made on "INetAddress" on zipkin package and on "HttpLogger" on zipkin-transport-http package.
The tests continue passing as it should.
Closes #195 