### PR TITLE
Update Endpoint isEmpty

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -80,7 +80,7 @@ declare namespace zipkin {
 
       map<V>(fn: (value: T) => V): IOption<V>;
       ifPresent<V>(fn: (value: T) => V): IOption<V>;
-      flatMap<V>(fn: (value: T) => V): IOption<V>;
+      flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
       getOrElse<V>(fnOrValue: (() => V) | V): T;
       equals(other: IOption<T>): boolean;
       toString(): string;
@@ -91,7 +91,7 @@ declare namespace zipkin {
       present: false;
 
       map<V>(fn: (value: any) => V): INone;
-      flatMap<V>(fn: (value: any) => V): INone;
+      flatMap<V>(fn: (value: any) => IOption<V>): INone;
       equals(other: IOption<any>): boolean;
       toString(): string;
     }
@@ -105,7 +105,7 @@ declare namespace zipkin {
 
       map: <V>(fn: (value: T) => V) => IOption<V>;
       ifPresent: <V>(fn: (value: T) => V) => IOption<V>;
-      flatMap: <V>(fn: (value: T) => V) => IOption<V>;
+      flatMap: <V>(fn: (value: T) => IOption<V>) => IOption<V>;
       getOrElse: () => T;
       equals: (other: IOption<T>) => boolean;
       toString: () => string;
@@ -124,7 +124,7 @@ declare namespace zipkin {
       setIpv4(ipv4: string): void;
       setPort(port: number): void;
 
-      isEmpty(): void;
+      isEmpty(): boolean;
     }
 
     interface Annotation {

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -80,7 +80,7 @@ declare namespace zipkin {
 
       map<V>(fn: (value: T) => V): IOption<V>;
       ifPresent<V>(fn: (value: T) => V): IOption<V>;
-      flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
+      flatMap<V>(fn: (value: T) => V): IOption<V>;
       getOrElse<V>(fnOrValue: (() => V) | V): T;
       equals(other: IOption<T>): boolean;
       toString(): string;
@@ -91,7 +91,7 @@ declare namespace zipkin {
       present: false;
 
       map<V>(fn: (value: any) => V): INone;
-      flatMap<V>(fn: (value: any) => IOption<V>): INone;
+      flatMap<V>(fn: (value: any) => V): INone;
       equals(other: IOption<any>): boolean;
       toString(): string;
     }
@@ -105,7 +105,7 @@ declare namespace zipkin {
 
       map: <V>(fn: (value: T) => V) => IOption<V>;
       ifPresent: <V>(fn: (value: T) => V) => IOption<V>;
-      flatMap: <V>(fn: (value: T) => IOption<V>) => IOption<V>;
+      flatMap: <V>(fn: (value: T) => V) => IOption<V>;
       getOrElse: () => T;
       equals: (other: IOption<T>) => boolean;
       toString: () => string;


### PR DESCRIPTION
I recently [ported the zipkin TS defs to Flow](https://github.com/flow-typed/flow-typed/pull/2953).  In the process, I found a couple types that seemed incorrect:

* Endpoint isEmpty's implementation returns a boolean, but the TS def was returning void.
* ~~The usual type of flatMap (i.e. monadic bind) is `(a -> Option b) -> Option a -> Option b`.  The TS types seemed to be identical to `map`, but the current Some flatMap implementation _seems_ to be similar to map + monadic join (using getOrElse as join).  I realize there may be a reason (historical?) for the TS type, but this change seemed right and I included it in this PR.~~ We decided to handle this in another PR ([see comment](https://github.com/openzipkin/zipkin-js/pull/280#issuecomment-439188846))

I included both of these changes in the Flow defs, so hopefully they're acceptable 😄.  Thanks for all your work on zipkin-js.