### PR TITLE
Update Option

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -74,42 +74,28 @@ declare namespace zipkin {
   const randomTraceId: () => string;
 
   namespace option {
-    interface IOption<T> {
-      type: 'Some' | 'None';
-      present: boolean;
-
+    abstract class IOptionMethods<T> {
       map<V>(fn: (value: T) => V): IOption<V>;
-      ifPresent<V>(fn: (value: T) => V): IOption<V>;
-      flatMap<V>(fn: (value: T) => V): IOption<V>;
-      getOrElse<V>(fnOrValue: (() => V) | V): T;
+      ifPresent<V>(fn: (value: T) => V): void;
+      flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
+      getOrElse(fnOrValue: (() => T) | T): T;
       equals(other: IOption<T>): boolean;
       toString(): string;
     }
 
-    interface INone extends IOption<any> {
-      type: 'None';
-      present: false;
-
-      map<V>(fn: (value: any) => V): INone;
-      flatMap<V>(fn: (value: any) => V): INone;
-      equals(other: IOption<any>): boolean;
-      toString(): string;
+    class Some<T> extends IOptionMethods<T> {
+      readonly type: 'Some';
+      readonly present: true;
     }
+
+    interface INone extends IOptionMethods<any> {
+      readonly type: 'None';
+      readonly present: false;
+    }
+
+    type IOption<T> = Some<T> | INone;
 
     const None: INone;
-
-    class Some<T> implements IOption<T> {
-      constructor(value: T);
-      type: 'Some' | 'None';
-      present: true;
-
-      map: <V>(fn: (value: T) => V) => IOption<V>;
-      ifPresent: <V>(fn: (value: T) => V) => IOption<V>;
-      flatMap: <V>(fn: (value: T) => V) => IOption<V>;
-      getOrElse: () => T;
-      equals: (other: IOption<T>) => boolean;
-      toString: () => string;
-    }
 
     function isOptional(data: any): boolean;
     function verifyIsOptional(data: any): void; // Throw error is not a valid option

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -76,7 +76,7 @@ declare namespace zipkin {
   namespace option {
     abstract class Option<T> {
       map<V>(fn: (value: T) => V): IOption<V>;
-      ifPresent(fn: (value: T) => void): void;
+      ifPresent(fn: (value: T) => any): void;
       flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
       getOrElse(fnOrValue: (() => T) | T): T;
       equals(other: IOption<T>): boolean;
@@ -84,19 +84,19 @@ declare namespace zipkin {
     }
 
     class Some<T> extends Option<T> {
-      constructor(public readonly value: T)
+      constructor(value: T);
       readonly type: 'Some';
       readonly present: true;
     }
 
-    interface INone extends Option<any> {
+    interface INone<T> extends Option<T> {
       readonly type: 'None';
       readonly present: false;
-    }
+   }
 
-    type IOption<T> = Some<T> | INone;
+    type IOption<T> = Some<T> | INone<T>;
 
-    const None: INone;
+    const None: INone<never>;
 
     function isOptional(data: any): boolean;
     function verifyIsOptional(data: any): void; // Throw error is not a valid option

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -76,7 +76,7 @@ declare namespace zipkin {
   namespace option {
     abstract class Option<T> {
       map<V>(fn: (value: T) => V): IOption<V>;
-      ifPresent<V>(fn: (value: T) => V): void;
+      ifPresent(fn: (value: T) => void): void;
       flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
       getOrElse(fnOrValue: (() => T) | T): T;
       equals(other: IOption<T>): boolean;

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -74,7 +74,7 @@ declare namespace zipkin {
   const randomTraceId: () => string;
 
   namespace option {
-    abstract class IOptionMethods<T> {
+    abstract class Option<T> {
       map<V>(fn: (value: T) => V): IOption<V>;
       ifPresent<V>(fn: (value: T) => V): void;
       flatMap<V>(fn: (value: T) => IOption<V>): IOption<V>;
@@ -83,12 +83,12 @@ declare namespace zipkin {
       toString(): string;
     }
 
-    class Some<T> extends IOptionMethods<T> {
+    class Some<T> extends Option<T> {
       readonly type: 'Some';
       readonly present: true;
     }
 
-    interface INone extends IOptionMethods<any> {
+    interface INone extends Option<any> {
       readonly type: 'None';
       readonly present: false;
     }

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -84,6 +84,7 @@ declare namespace zipkin {
     }
 
     class Some<T> extends Option<T> {
+      constructor(public readonly value: T)
       readonly type: 'Some';
       readonly present: true;
     }

--- a/packages/zipkin/src/option.js
+++ b/packages/zipkin/src/option.js
@@ -2,44 +2,45 @@ const None = {
   get type() {
     return 'None';
   },
+  get present() {
+    return false;
+  },
   map() {
-    return None;
+    return this;
   },
   ifPresent() {},
   flatMap() {
-    return None;
+    return this;
   },
   getOrElse(f) {
-    if (f instanceof Function) {
-      return f();
-    } else {
-      return f;
-    }
+    return f instanceof Function ? f() : f;
   },
   equals(other) {
-    return other.type === 'None';
+    return other === this;
   },
   toString() {
     return 'None';
-  },
-  get present() {
-    return false;
   }
 };
-
 
 class Some {
   constructor(value) {
     this.value = value;
   }
+  get type() {
+    return 'Some';
+  }
+  get present() {
+    return true;
+  }
   map(f) {
     return new Some(f(this.value));
   }
   ifPresent(f) {
-    return this.map(f);
+    f(this.value);
   }
   flatMap(f) {
-    return this.map(f).getOrElse(None);
+    return f(this.value);
   }
   getOrElse() {
     return this.value;
@@ -48,24 +49,13 @@ class Some {
     return other instanceof Some && other.value === this.value;
   }
   toString() {
-    return `Some(${this.value.toString()})`;
-  }
-  get present() {
-    return true;
-  }
-  get type() {
-    return 'Some';
+    return `Some(${this.value})`;
   }
 }
 
 // Used to validate input arguments
 function isOptional(data) {
-  return data != null && (
-      data instanceof Some ||
-      data === None ||
-      data.type === 'Some' ||
-      data.type === 'None'
-    );
+  return data instanceof Some || None.equals(data);
 }
 
 function verifyIsOptional(data) {
@@ -74,7 +64,7 @@ function verifyIsOptional(data) {
   }
   if (isOptional(data)) {
     if (isOptional(data.value)) {
-      throw new Error(`Error: data (${data.value.toString()}) is wrapped in Option twice`);
+      throw new Error(`Error: data (${data.value}) is wrapped in Option twice`);
     }
   } else {
     throw new Error(`Error: data (${data}) is not an Option!`);
@@ -82,17 +72,13 @@ function verifyIsOptional(data) {
 }
 
 function verifyIsNotOptional(data) {
-  if (data != null && isOptional(data)) {
+  if (isOptional(data)) {
     throw new Error(`Error: data (${data}) is an Option!`);
   }
 }
 
 function fromNullable(nullable) {
-  if (nullable != null) {
-    return new Some(nullable);
-  } else {
-    return None;
-  }
+  return nullable == null ? None : new Some(nullable);
 }
 
 module.exports.Some = Some;

--- a/packages/zipkin/test-types/option.test.ts
+++ b/packages/zipkin/test-types/option.test.ts
@@ -68,13 +68,13 @@ describe('Option', () => {
         });
 
         it('ifPresent should return void', () => {
-            const value: IOption<number> = new Some(0)
+            const value: IOption<number> = new Some(0);
             const x: void = value.ifPresent(v => v);
 
             expect(x).to.equal(undefined);
-        })
+        });
 
-       it('map should have correct return types', () => {
+        it('map should have correct return types', () => {
             const value: IOption<string> = new Some('some value');
 
             const mappedValue: IOption<number> = value.map(v => v.length);

--- a/packages/zipkin/test-types/option.test.ts
+++ b/packages/zipkin/test-types/option.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import { option } from 'zipkin';
+import IOption = option.IOption;
+import Some = option.Some;
+import None = option.None;
+
+describe('Option', () => {
+    describe('None', () => {
+        it('type should be of expected type', () => {
+            const t: 'None' = None.type;
+
+            expect(t).to.equal('None');
+        });
+
+        it('present should be of expected type', () => {
+            const p: false = None.present;
+
+            expect(p).to.equal(false);
+        });
+
+        it('getOrElse should return value type', () => {
+            const value: IOption<number> = None;
+
+            expect(value.getOrElse(0)).to.equal(0);
+            expect(value.getOrElse(() => 0)).to.equal(0);
+        });
+
+        it('ifPresent should return void', () => {
+            const value: IOption<number> = None;
+            const x: void = value.ifPresent(v => v);
+
+            expect(x).to.equal(undefined);
+        });
+
+        it('map should have correct return types', () => {
+            const mappedValue: IOption<any> = None.map(v => v);
+
+            expect(mappedValue).to.equal(None);
+        });
+
+        it('flatMap should have correct return types', () => {
+            const mappedValue1: IOption<any> = None.flatMap(v => new Some(v));
+            const mappedValue2: IOption<any> = None.flatMap(_ => None);
+
+            expect(mappedValue1).to.equal(None);
+            expect(mappedValue2).to.equal(None);
+        });
+    });
+
+    describe('Some', () => {
+        it('type should be of expected type', () => {
+            const t: 'Some' = new Some(0).type;
+
+            expect(t).to.equal('Some');
+        });
+
+        it('present should be of expected type', () => {
+            const p: true = new Some(0).present;
+
+            expect(p).to.equal(true);
+        });
+
+        it('getOrElse should return value type', () => {
+            const value: IOption<number> = new Some(0);
+
+            expect(value.getOrElse(1)).to.equal(0);
+            expect(value.getOrElse(() => 1)).to.equal(0);
+        });
+
+        it('ifPresent should return void', () => {
+            const value: IOption<number> = new Some(0)
+            const x: void = value.ifPresent(v => v);
+
+            expect(x).to.equal(undefined);
+        })
+
+       it('map should have correct return types', () => {
+            const value: IOption<string> = new Some('some value');
+
+            const mappedValue: IOption<number> = value.map(v => v.length);
+
+            expect(mappedValue.type).to.equal('Some');
+            expect(mappedValue.getOrElse(0)).to.equal('some value'.length);
+        });
+
+        it('flatMap should have correct return types', () => {
+            const value = new Some('some value');
+
+            const mappedValue1: IOption<number> = value.flatMap(v => new Some(v.length));
+            const mappedValue2: IOption<number> = value.flatMap(_ => None);
+
+            expect(mappedValue1.getOrElse(0)).to.equal('some value'.length);
+            expect(mappedValue2.getOrElse(0)).to.equal(0);
+        });
+    });
+});

--- a/packages/zipkin/test-types/option.test.ts
+++ b/packages/zipkin/test-types/option.test.ts
@@ -1,21 +1,18 @@
 import { expect } from 'chai';
 import { option } from 'zipkin';
 import IOption = option.IOption;
+import INone = option.INone;
 import Some = option.Some;
 import None = option.None;
 
 describe('Option', () => {
     describe('None', () => {
-        it('type should be of expected type', () => {
-            const t: 'None' = None.type;
+        it('should have expected interface', () => {
+            // Both type and present will be checked by ts-runtime
+            const value: INone<never> = None;
 
-            expect(t).to.equal('None');
-        });
-
-        it('present should be of expected type', () => {
-            const p: false = None.present;
-
-            expect(p).to.equal(false);
+            // Avoid unused value warning
+            expect(value.type).to.equal('None');
         });
 
         it('getOrElse should return value type', () => {
@@ -48,16 +45,12 @@ describe('Option', () => {
     });
 
     describe('Some', () => {
-        it('type should be of expected type', () => {
-            const t: 'Some' = new Some(0).type;
+        it('should have expected interface', () => {
+            // Both type and present will be checked by ts-runtime
+            const value: IOption<number> = new Some(0);
 
-            expect(t).to.equal('Some');
-        });
-
-        it('present should be of expected type', () => {
-            const p: true = new Some(0).present;
-
-            expect(p).to.equal(true);
+            // Avoid unused value warning
+            expect(value.type).to.equal('Some');
         });
 
         it('getOrElse should return value type', () => {

--- a/packages/zipkin/test/option.test.js
+++ b/packages/zipkin/test/option.test.js
@@ -1,0 +1,77 @@
+const option = require('../src/option');
+
+describe('option', () => {
+  describe('Some', () => {
+    describe('getOrElse', () => {
+      it('should return Some value', () => {
+        const s = new option.Some(0);
+
+        expect(s.getOrElse(1)).to.equal(0);
+      });
+    });
+
+    describe('map', () => {
+      it('should map value', () => {
+        const s = new option.Some('a');
+
+        expect(s.map(x => `${x}1`).getOrElse('z')).to.equal('a1');
+      });
+
+      // https://wiki.haskell.org/Functor#Functor_Laws
+      it('should satisfy identity', () => {
+        const a = 'a';
+        const s = new option.Some(a);
+
+        expect(s.map(x => x).getOrElse('z')).to.equal(s.getOrElse('zz'));
+      });
+
+      it('should satisfy composition', () => {
+        const f = x => `${x}1`;
+        const g = x => `${x}2`;
+        const s0 = new option.Some('a');
+        const s1 = s0.map(f).map(g);
+        const s2 = s0.map(x => g(f(x)));
+
+        expect(s1.getOrElse('z')).to.equal(s2.getOrElse('zz'));
+      });
+    });
+
+    describe('flatMap', () => {
+      // https://wiki.haskell.org/Monad_laws
+      it('should satisfy left identity', () => {
+        const a = 'a';
+        const f = x => new option.Some(x);
+        const s1 = new option.Some(a).flatMap(f);
+        const s2 = f(a);
+
+        expect(s1.getOrElse('z')).to.equal(s2.getOrElse('zz'));
+      });
+
+      it('should satisfy right identity', () => {
+        const f = x => new option.Some(x);
+        const s0 = new option.Some('a');
+        const s1 = s0.flatMap(f);
+
+        expect(s0.getOrElse('z')).to.equal(s1.getOrElse('zz'));
+      });
+
+      it('should satisfy associativity', () => {
+        const f = x => new option.Some(`${x}1`);
+        const g = x => new option.Some(`${x}2`);
+        const s0 = new option.Some('a');
+        const s1 = s0.flatMap(f).flatMap(g);
+        const s2 = s0.flatMap(x => f(x).flatMap(g));
+
+        expect(s1.getOrElse('z')).to.equal(s2.getOrElse('zz'));
+      });
+    });
+  });
+
+  describe('None', () => {
+    describe('getOrElse', () => {
+      it('should return Some value', () => {
+        expect(option.None.getOrElse(1)).to.equal(1);
+      });
+    });
+  });
+});

--- a/packages/zipkin/test/option.test.js
+++ b/packages/zipkin/test/option.test.js
@@ -10,6 +10,20 @@ describe('option', () => {
       });
     });
 
+    describe('ifPresent', () => {
+      it('should invoke function', () => {
+        const s = new option.Some(0);
+
+        let called = false;
+        s.ifPresent(x => {
+          expect(x).to.equal(0);
+          called = true;
+        });
+
+        expect(called).to.be.true; // eslint-disable-line no-unused-expressions
+      });
+    });
+
     describe('map', () => {
       it('should map value', () => {
         const s = new option.Some('a');
@@ -65,12 +79,64 @@ describe('option', () => {
         expect(s1.getOrElse('z')).to.equal(s2.getOrElse('zz'));
       });
     });
+
+    describe('equals', () => {
+      it('should be false for None', () => {
+        const isEqual = new option.Some(0).equals(option.None);
+        expect(isEqual).to.be.false; // eslint-disable-line no-unused-expressions
+      });
+
+      it('should be false for Some with unequal value', () => {
+        const isEqual = new option.Some(0).equals(new option.Some(1));
+        expect(isEqual).to.be.false; // eslint-disable-line no-unused-expressions
+      });
+
+      it('should be true for Some with equal value', () => {
+        const isEqual = new option.Some(0).equals(new option.Some(0));
+        expect(isEqual).to.be.true; // eslint-disable-line no-unused-expressions
+      });
+    });
   });
 
   describe('None', () => {
     describe('getOrElse', () => {
-      it('should return Some value', () => {
+      it('should return else value', () => {
         expect(option.None.getOrElse(1)).to.equal(1);
+      });
+    });
+
+    describe('ifPresent', () => {
+      it('should not invoke function', () => {
+        option.None.ifPresent(() => {
+          expect.fail('None.ifPresent should not invoke function, but did');
+        });
+      });
+    });
+
+    // Sufficient for Functor laws
+    describe('map', () => {
+      it('should return None', () => {
+        expect(option.None.map(x => x)).to.equal(option.None);
+      });
+    });
+
+    // Sufficient for Monad laws
+    describe('flatMap', () => {
+      it('should return None', () => {
+        expect(option.None.flatMap(x => new option.Some(x))).to.equal(option.None);
+        expect(option.None.flatMap(() => option.None)).to.equal(option.None);
+      });
+    });
+
+    describe('equals', () => {
+      it('should be true for None', () => {
+        const isEqual = option.None.equals(option.None);
+        expect(isEqual).to.be.true; // eslint-disable-line no-unused-expressions
+      });
+
+      it('should be false for Some', () => {
+        const isEqual = option.None.equals(new option.Some(0));
+        expect(isEqual).to.be.false; // eslint-disable-line no-unused-expressions
       });
     });
   });


### PR DESCRIPTION
Follow up to #280, specifically [here](https://github.com/openzipkin/zipkin-js/pull/280#issuecomment-439145978)

Update Option type and implementation:

* flatMap -> proper bind semantics
* ifPresent -> return void to reflect side-effecting intent
* getOrElse -> guarantee T return type
* Simplify type hierarchy
    * **Note** this removes some of the existing INone refinements in favor of simpler (imho) types overall.  It wasn't clear the refinements were providing any concrete value, but if they are, please let me know!

Thanks to @TylorS for the abstract class suggestion as a way to simplify the types.

### Todo

- [x] Add type tests
- [x] Update implementation to match updated types
- [x] Add implementation tests
- [x] Update usages ([verified no changes needed](https://github.com/openzipkin/zipkin-js/pull/286#discussion_r235513557))