### PR TITLE
Change the lint:ts command to match all sub-folders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "audit": "lerna exec npm audit",
     "audit:fix": "lerna exec npm audit fix",
     "lint:es": "eslint packages",
-    "lint:ts": "tslint -c tslint.json -e \"./packages/**/node_modules/**/*.ts\" packages/**/*.ts",
+    "lint:ts": "tslint -c tslint.json -e './packages/**/node_modules/**/*.ts' './packages/**/*.ts'",
     "lint": "npm-run-all --parallel lint:*",
     "test:es": "npm run lerna-test",
     "test:ts": "tsr packages/zipkin/test-types/*.test.ts --noAnnotate --libDeclarations && mocha --opts test/mocha-types.opts",

--- a/packages/zipkin/test-types/TraceId.test.ts
+++ b/packages/zipkin/test-types/TraceId.test.ts
@@ -1,5 +1,5 @@
-import { TraceId, option } from 'zipkin';
 import { expect } from 'chai';
+import { option, TraceId } from 'zipkin';
 
 describe('TraceId', () => {
   it('should have correct type', () => {

--- a/packages/zipkin/test-types/annotation.test.ts
+++ b/packages/zipkin/test-types/annotation.test.ts
@@ -1,5 +1,5 @@
-import { Annotation, InetAddress } from 'zipkin';
 import {expect} from 'chai';
+import { Annotation, InetAddress } from 'zipkin';
 
 describe('Annotation types', () => {
     describe('[ClientSend, ClientRecv, ServerSend, ServerRecv, LocalOperationStop]', () => {

--- a/packages/zipkin/test-types/context.test.ts
+++ b/packages/zipkin/test-types/context.test.ts
@@ -1,5 +1,5 @@
-import { ExplicitContext } from 'zipkin';
 import {expect} from 'chai';
+import { ExplicitContext } from 'zipkin';
 
 describe('ExplicitContext', () => {
     it('should return correct type', () => {

--- a/packages/zipkin/test-types/inetAddress.test.ts
+++ b/packages/zipkin/test-types/inetAddress.test.ts
@@ -1,5 +1,5 @@
-import { InetAddress } from 'zipkin';
 import { expect } from 'chai';
+import { InetAddress } from 'zipkin';
 
 describe('InetAddress', () => {
   it('should have correct type', () => {

--- a/packages/zipkin/test-types/instrumentation.test.ts
+++ b/packages/zipkin/test-types/instrumentation.test.ts
@@ -1,5 +1,5 @@
-import {Instrumentation, Tracer, ExplicitContext, ConsoleRecorder} from 'zipkin';
 import {expect} from 'chai';
+import {ConsoleRecorder, ExplicitContext, Instrumentation, Tracer} from 'zipkin';
 
 describe('Instrumentation', () => {
     describe('HttpClient', () => {
@@ -7,7 +7,7 @@ describe('Instrumentation', () => {
             const instrumentation: Instrumentation.HttpClient = new Instrumentation.HttpClient({
                     tracer: new Tracer({
                         ctxImpl: new ExplicitContext(),
-                        recorder: new ConsoleRecorder(),
+                        recorder: new ConsoleRecorder()
                     }),
                     serviceName: 'weather-app',
                     remoteServiceName: 'weather-forecast-service'
@@ -22,9 +22,9 @@ describe('Instrumentation', () => {
             const instrumentation: Instrumentation.HttpServer = new Instrumentation.HttpServer({
                     tracer: new Tracer({
                         ctxImpl: new ExplicitContext(),
-                        recorder: new ConsoleRecorder(),
+                        recorder: new ConsoleRecorder()
                     }),
-                    port: 8000,
+                    port: 8000
                 }
             );
 

--- a/packages/zipkin/test-types/jsonEncoder.test.ts
+++ b/packages/zipkin/test-types/jsonEncoder.test.ts
@@ -1,5 +1,5 @@
-import { jsonEncoder, JsonEncoder, model, TraceId, option } from 'zipkin';
 import { expect } from 'chai';
+import { jsonEncoder, JsonEncoder, model, option, TraceId } from 'zipkin';
 
 describe('JsonEncoder', () => {
     it('should have correct type', () => {

--- a/packages/zipkin/test-types/model.test.ts
+++ b/packages/zipkin/test-types/model.test.ts
@@ -1,5 +1,5 @@
-import {model, option, TraceId} from 'zipkin';
 import {expect} from 'chai';
+import {model, option, TraceId} from 'zipkin';
 
 describe('Model', () => {
     describe('Endpoint', () => {
@@ -7,7 +7,7 @@ describe('Model', () => {
             const endpoint: model.Endpoint = new model.Endpoint({
                 serviceName: 'Unknown',
                 ipv4: '10.0.0.1',
-                port: 8000,
+                port: 8000
             });
 
             expect(endpoint.setIpv4).to.be.a('function');
@@ -17,7 +17,7 @@ describe('Model', () => {
         it('should have correct type', () => {
             const span: model.Span = new model.Span(new TraceId({
                 traceId: new option.Some('a'),
-                spanId: 'b',
+                spanId: 'b'
             }));
 
             expect(span.traceId).to.be.a('string');

--- a/packages/zipkin/test-types/randomTraceId.test.ts
+++ b/packages/zipkin/test-types/randomTraceId.test.ts
@@ -1,5 +1,5 @@
-import { randomTraceId } from 'zipkin';
 import { expect } from 'chai';
+import { randomTraceId } from 'zipkin';
 
 describe('RandomTraceId', () => {
   it('should return string', () => {

--- a/packages/zipkin/test-types/recorder.test.ts
+++ b/packages/zipkin/test-types/recorder.test.ts
@@ -1,15 +1,16 @@
-import { ConsoleRecorder, BatchRecorder, Logger, model } from 'zipkin';
 import {expect} from 'chai';
+import { BatchRecorder, ConsoleRecorder, Logger, model } from 'zipkin';
 
 describe('Recorder types', () => {
     describe('BatchRecorder', () => {
         it('should return correct type', () => {
+            class Log implements Logger {
+                logSpan(span: model.Span): void {
+                }
+            }
             const batchRecorder: BatchRecorder = new BatchRecorder({
-                logger: new class implements Logger {
-                    logSpan(span: model.Span): void {
-                    }
-                },
-                timeout: 1000,
+                logger: new Log(),
+                timeout: 1000
             });
 
             expect(batchRecorder.record).to.be.a('function');

--- a/packages/zipkin/test-types/request.test.ts
+++ b/packages/zipkin/test-types/request.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import {Request, TraceId, option, RequestZipkinHeaders} from 'zipkin';
+import {option, Request, RequestZipkinHeaders, TraceId} from 'zipkin';
 import Some = option.Some;
 
 describe('Request', () => {
@@ -25,7 +25,7 @@ describe('Request', () => {
                 spanId: '48485a3953bb6124'
             });
 
-            const requestWithCookie: RequestZipkinHeaders<{ url : string}, { cookie: string }> =
+            const requestWithCookie: RequestZipkinHeaders<{ url: string}, { cookie: string }> =
                 Request.addZipkinHeaders(
                     { url: 'google.com', headers: { cookie: 'abc' } },
                     traceId

--- a/packages/zipkin/test-types/sampler.test.ts
+++ b/packages/zipkin/test-types/sampler.test.ts
@@ -1,5 +1,5 @@
-import { sampler } from 'zipkin';
 import { expect } from 'chai';
+import { sampler } from 'zipkin';
 
 describe('Sampler', () => {
   it('should have correct type', () => {

--- a/packages/zipkin/test-types/trace.test.ts
+++ b/packages/zipkin/test-types/trace.test.ts
@@ -1,5 +1,5 @@
-import { Tracer, ExplicitContext } from 'zipkin';
 import { expect } from 'chai';
+import { ExplicitContext, Tracer } from 'zipkin';
 
 describe('Tracer', () => {
   it('should have correct type', () => {


### PR DESCRIPTION
Issue: `lint:ts` command doesn't lint all of the sub-folders.
Fix: Change the `lint:ts` command to match all sub-folders.

The discussion in #286 where there were some missing semicolons in the PR.