### PR TITLE
adds configurable logging module as argument and defaults to console

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 gen-nodejs
 lib
+**/test-types/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn-error.log
 packages/**/package-lock.json
 **/test-types/*.test.js
 **/tsr-declarations.js
+.idea/

--- a/packages/zipkin-transport-http/README.md
+++ b/packages/zipkin-transport-http/README.md
@@ -12,13 +12,15 @@ const {
   jsonEncoder: {JSON_V2}
 } = require('zipkin');
 const {HttpLogger} = require('zipkin-transport-http');
+const noop = require('noop-logger');
 
 const recorder = new BatchRecorder({
   logger: new HttpLogger({
     endpoint: 'http://localhost:9411/api/v2/spans',
     jsonEncoder: JSON_V2, // optional, defaults to JSON_V1
     httpInterval: 1000, // how often to sync spans. optional, defaults to 1000
-    headers: {'Authorization': 'secret'} // optional custom HTTP headers
+    headers: {'Authorization': 'secret'}, // optional custom HTTP headers
+    log: noop // optional (defaults to console)
   })
 });
 

--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,7 +1,14 @@
 import {JsonEncoder, Logger, model} from 'zipkin';
 
 declare class HttpLogger implements Logger {
-  constructor(options: {endpoint: string, httpInterval?: number, jsonEncoder?: JsonEncoder, httpTimeout?: number, headers?: { [name: string]: any }});
+  constructor(options: {
+    endpoint: string,
+    httpInterval?: number,
+    jsonEncoder?: JsonEncoder,
+    httpTimeout?: number,
+    headers?: { [name: string]: any },
+    log?: Console
+  });
   logSpan(span: model.Span): void;
 }
 export {HttpLogger};

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -13,8 +13,17 @@ const {
 const EventEmitter = require('events').EventEmitter;
 
 class HttpLogger extends EventEmitter {
-  constructor({endpoint, headers = {}, httpInterval = 1000, jsonEncoder = JSON_V1, timeout = 0}) {
+  constructor({
+    endpoint,
+    headers = {},
+    httpInterval = 1000,
+    jsonEncoder = JSON_V1,
+    timeout = 0,
+    /* eslint-disable no-console */
+    log = console
+  }) {
     super(); // must be before any reference to *this*
+    this.log = log;
     this.endpoint = endpoint;
     this.queue = [];
     this.jsonEncoder = jsonEncoder;
@@ -41,7 +50,7 @@ class HttpLogger extends EventEmitter {
   on(...args) {
     const eventName = args[0];
     // if the instance has an error handler set then we don't need to
-    // console.log errors anymore
+    // skips error logging
     if (eventName.toLowerCase() === 'error') this.errorListenerSet = true;
     super.on.apply(this, args);
   }
@@ -65,14 +74,14 @@ class HttpLogger extends EventEmitter {
             `${response.status}, body: ${postBody}`;
 
           if (self.errorListenerSet) this.emit('error', new Error(err));
-          else console.error(err);
+          else this.log.error(err);
         } else {
           this.emit('success', response);
         }
       }).catch((error) => {
         const err = `Error sending Zipkin data ${error}`;
         if (self.errorListenerSet) this.emit('error', new Error(err));
-        else console.error(err);
+        else this.log.error(err);
       });
       self.queue.length = 0;
     }

--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -6,12 +6,34 @@ const HttpLogger = require('../src/HttpLogger');
 const express = require('express');
 const bodyParser = require('body-parser');
 
+const mockPublisher = (serverExpectations) => {
+  const app = express();
+  app.use(bodyParser.json());
+  app.post('/api/v1/spans', (req, res) => {
+    res.status(202).json({});
+    serverExpectations(req, res);
+  });
+  return app;
+};
+
+const triggerPublish = (logger) => {
+  const ctxImpl = new ExplicitContext();
+  const recorder = new BatchRecorder({logger});
+  const tracer = new Tracer({recorder, ctxImpl});
+
+  ctxImpl.scoped(() => {
+    tracer.recordAnnotation(new Annotation.ServerRecv());
+    tracer.recordServiceName('my-service');
+    tracer.recordRpc('GET');
+    tracer.recordBinary('http.url', 'http://example.com');
+    tracer.recordBinary('http.response_code', '200');
+    tracer.recordAnnotation(new Annotation.ServerSend());
+  });
+};
+
 describe('HTTP transport - integration test', () => {
   it('should send trace data via HTTP using JSON_V1', function(done) {
-    const app = express();
-    app.use(bodyParser.json());
-    app.post('/api/v1/spans', (req, res) => {
-      res.status(202).json({});
+    const app = mockPublisher((req) => {
       expect(req.headers['content-type']).to.equal('application/json');
       const traceData = req.body;
       expect(traceData.length).to.equal(1);
@@ -20,32 +42,20 @@ describe('HTTP transport - integration test', () => {
       expect(traceData[0].annotations.length).to.equal(2);
       this.server.close(done);
     });
+
     this.server = app.listen(0, () => {
       this.port = this.server.address().port;
       const httpLogger = new HttpLogger({
-        endpoint: `http://localhost:${this.port}/api/v1/spans`
+        endpoint: `http://localhost:${this.port}/api/v1/spans`,
+        httpInterval: 1,
       });
 
-      const ctxImpl = new ExplicitContext();
-      const recorder = new BatchRecorder({logger: httpLogger});
-      const tracer = new Tracer({recorder, ctxImpl});
-
-      ctxImpl.scoped(() => {
-        tracer.recordAnnotation(new Annotation.ServerRecv());
-        tracer.recordServiceName('my-service');
-        tracer.recordRpc('GET');
-        tracer.recordBinary('http.url', 'http://example.com');
-        tracer.recordBinary('http.response_code', '200');
-        tracer.recordAnnotation(new Annotation.ServerSend());
-      });
+      triggerPublish(httpLogger);
     });
   });
 
   it('should send trace data via HTTP using JSON_V2', function(done) {
-    const app = express();
-    app.use(bodyParser.json());
-    app.post('/api/v1/spans', (req, res) => {
-      res.status(202).json({});
+    const app = mockPublisher((req) => {
       expect(req.headers['content-type']).to.equal('application/json');
       expect(req.headers.authorization).to.equal('Token');
       const traceData = req.body;
@@ -56,95 +66,72 @@ describe('HTTP transport - integration test', () => {
       expect(traceData[0].tags['http.response_code']).to.equal('200');
       this.server.close(done);
     });
+
     this.server = app.listen(0, () => {
       this.port = this.server.address().port;
       const httpLogger = new HttpLogger({
         endpoint: `http://localhost:${this.port}/api/v1/spans`,
         headers: {Authorization: 'Token'},
-        jsonEncoder: JSON_V2
+        jsonEncoder: JSON_V2,
+        httpInterval: 1
       });
 
-      const ctxImpl = new ExplicitContext();
-      const recorder = new BatchRecorder({logger: httpLogger});
-      const tracer = new Tracer({recorder, ctxImpl});
-
-      ctxImpl.scoped(() => {
-        tracer.recordAnnotation(new Annotation.ServerRecv());
-        tracer.recordServiceName('my-service');
-        tracer.recordRpc('GET');
-        tracer.recordBinary('http.url', 'http://example.com');
-        tracer.recordBinary('http.response_code', '200');
-        tracer.recordAnnotation(new Annotation.ServerSend());
-      });
+      triggerPublish(httpLogger);
     });
   });
 
   it('should emit an error when an error listener is set', function(done) {
     const self = this;
-    const app = express();
-    app.use(bodyParser.json());
-    app.post('/api/v1/spans', (req, res) => {
-      res.status(202).json({});
-    });
+    const app = mockPublisher(() => {});
+
     self.server = app.listen(0, () => {
       self.port = self.server.address().port;
       const httpLogger = new HttpLogger({
         endpoint: `http://localhost:${self.port}/api/v1/spans/causeerror`,
-        headers: {Authorization: 'Token'},
-        jsonEncoder: JSON_V2
+        jsonEncoder: JSON_V2,
+        httpInterval: 1
       });
 
-      httpLogger.on('error', () => {
-        // if an error was emitted then this works
-        self.server.close(done);
+      // if an error was emitted then this works
+      httpLogger.on('error', () => { self.server.close(done); });
+      triggerPublish(httpLogger);
+    });
+  });
+
+  it('should log if an error listener is not set', function(done) {
+    const self = this;
+    const app = mockPublisher(() => {});
+
+    // if an error was emitted then this works
+    const log = {error: () => self.server.close(done)};
+
+    self.server = app.listen(0, () => {
+      self.port = self.server.address().port;
+      const httpLogger = new HttpLogger({
+        endpoint: `http://localhost:${self.port}/api/v1/spans/causeerror`,
+        jsonEncoder: JSON_V2,
+        httpInterval: 1,
+        log
       });
 
-      const ctxImpl = new ExplicitContext();
-      const recorder = new BatchRecorder({logger: httpLogger});
-      const tracer = new Tracer({recorder, ctxImpl});
-
-      ctxImpl.scoped(() => {
-        tracer.recordAnnotation(new Annotation.ServerRecv());
-        tracer.recordServiceName('my-service');
-        tracer.recordRpc('GET');
-        tracer.recordBinary('http.url', 'http://example.com');
-        tracer.recordBinary('http.response_code', '200');
-        tracer.recordAnnotation(new Annotation.ServerSend());
-      });
+      triggerPublish(httpLogger);
     });
   });
 
   it('should accept a 200 response from the server', function(done) {
     const self = this;
-    const app = express();
-    app.use(bodyParser.json());
-    app.post('/api/v1/spans', (req, res) => {
-      res.status(200).json({});
-    });
+    const app = mockPublisher(() => {});
+
     this.server = app.listen(0, () => {
       this.port = this.server.address().port;
       const httpLogger = new HttpLogger({
         endpoint: `http://localhost:${this.port}/api/v1/spans`,
-        headers: {Authorization: 'Token'},
-        jsonEncoder: JSON_V2
+        jsonEncoder: JSON_V2,
+        httpInterval: 1
       });
 
-      httpLogger.on('success', () => {
-        self.server.close(done);
-      });
-
-      const ctxImpl = new ExplicitContext();
-      const recorder = new BatchRecorder({logger: httpLogger});
-      const tracer = new Tracer({recorder, ctxImpl});
-
-      ctxImpl.scoped(() => {
-        tracer.recordAnnotation(new Annotation.ServerRecv());
-        tracer.recordServiceName('my-service');
-        tracer.recordRpc('GET');
-        tracer.recordBinary('http.url', 'http://example.com');
-        tracer.recordBinary('http.response_code', '200');
-        tracer.recordAnnotation(new Annotation.ServerSend());
-      });
+      httpLogger.on('success', () => { self.server.close(done); });
+      triggerPublish(httpLogger);
     });
   });
 });

--- a/packages/zipkin-transport-kafka/README.md
+++ b/packages/zipkin-transport-kafka/README.md
@@ -9,12 +9,14 @@ This is a module that sends Zipkin trace data from zipkin-js to Kafka.
 ```javascript
 const {Tracer, BatchRecorder} = require('zipkin');
 const {KafkaLogger} = require('zipkin-transport-kafka');
+const noop = require('noop-logger');
 
 const kafkaRecorder = new BatchRecorder({
   logger: new KafkaLogger({
     clientOpts: {
       connectionString: 'localhost:2181'
-    }
+    },
+    log: noop // optional (defaults to console)
   })
 });
 

--- a/packages/zipkin-transport-kafka/index.d.ts
+++ b/packages/zipkin-transport-kafka/index.d.ts
@@ -2,7 +2,12 @@ import {KafkaClientOptions, ProducerOptions, ZKOptions} from 'kafka-node';
 import {Logger, model} from 'zipkin';
 
 declare class KafkaLogger implements Logger {
-  constructor(options: {topic?: string, clientOpts?: KafkaClientOptions | {connectionString: string, clientId?: string, zkOpts: ZKOptions}, producerOpts?: ProducerOptions});
+  constructor(options: {
+    topic?: string,
+    clientOpts?: KafkaClientOptions | {connectionString: string, clientId?: string, zkOpts: ZKOptions},
+    producerOpts?: ProducerOptions,
+    log?: Console
+  });
   logSpan(span: model.Span): void;
 }
 export {KafkaLogger};

--- a/packages/zipkin-transport-kafka/src/KafkaLogger.js
+++ b/packages/zipkin-transport-kafka/src/KafkaLogger.js
@@ -11,10 +11,11 @@ module.exports = class KafkaLogger {
     const producerDefaults = {
       requireAcks: 0
     };
+    /* eslint-disable no-console */
+    const log = options.log || console;
     const producerOpts = Object.assign({}, producerDefaults, options.producerOpts || {});
     this.onError = options.onError || function(err) {
-      /* eslint-disable no-console */
-      console.error(err);
+      log.error(err);
     };
 
     this.topic = options.topic || 'zipkin';

--- a/packages/zipkin-transport-scribe/README.md
+++ b/packages/zipkin-transport-scribe/README.md
@@ -9,12 +9,14 @@ This is a module that sends Zipkin trace data from zipkin-js to Scribe or Fluent
 ```javascript
 const {Tracer, BatchRecorder} = require('zipkin');
 const {ScribeLogger} = require('zipkin-transport-scribe');
+const noop = require('noop-logger');
 
 const scribeRecorder = new BatchRecorder({
   logger: new ScribeLogger({
     scribeHost: '127.0.0.1',
     scribePort: port,
-    scribeInterval: 1
+    scribeInterval: 1,
+    log: noop // optional (defaults to console)
   })
 });
 

--- a/packages/zipkin-transport-scribe/index.d.ts
+++ b/packages/zipkin-transport-scribe/index.d.ts
@@ -1,7 +1,12 @@
 import {Logger, model} from 'zipkin';
 
 declare class ScribeLogger implements Logger {
-  constructor(options: {scribeHost: string, scribePort?: number, scribeInterval?: number});
+  constructor(options: {
+    scribeHost: string,
+    scribePort?: number,
+    scribeInterval?: number,
+    log?: Console
+  });
   logSpan(span: model.Span): void;
 }
 export {ScribeLogger};

--- a/packages/zipkin-transport-scribe/src/ScribeLogger.js
+++ b/packages/zipkin-transport-scribe/src/ScribeLogger.js
@@ -3,7 +3,7 @@ const {Scribe} = require('scribe');
 const {fromByteArray: base64encode} = require('base64-js');
 const THRIFT = require('zipkin-encoder-thrift');
 
-function ScribeLogger({scribeHost, scribePort = 9410, scribeInterval = 1000}) {
+function ScribeLogger({scribeHost, scribePort = 9410, scribeInterval = 1000, log = console}) {
   const scribeClient = new Scribe(scribeHost, scribePort, {autoReconnect: true});
   scribeClient.on('error', () => {});
 
@@ -14,7 +14,7 @@ function ScribeLogger({scribeHost, scribePort = 9410, scribeInterval = 1000}) {
       try {
         scribeClient.open((err) => {
           if (err) {
-            console.error('Error writing Zipkin data to Scribe', err);
+            log.error('Error writing Zipkin data to Scribe', err);
           } else {
             this.queue.forEach((span) => {
               scribeClient.send('zipkin', base64encode(THRIFT.encode(span)));
@@ -24,7 +24,7 @@ function ScribeLogger({scribeHost, scribePort = 9410, scribeInterval = 1000}) {
           }
         });
       } catch (err) {
-        console.error('Error writing Zipkin data to Scribe', err);
+        log.error('Error writing Zipkin data to Scribe', err);
       }
     }
   }, scribeInterval);

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -30,7 +30,16 @@ declare namespace zipkin {
   }
 
   class Tracer {
-    constructor(args: { ctxImpl: Context<TraceId>, recorder: Recorder, sampler?: sampler.Sampler, traceId128Bit?: boolean, localServiceName?: string, localEndpoint?: model.Endpoint });
+    constructor(args: {
+      ctxImpl: Context<TraceId>,
+      recorder: Recorder,
+      sampler?: sampler.Sampler,
+      traceId128Bit?: boolean,
+      localServiceName?: string,
+      localEndpoint?: model.Endpoint,
+      log?: Console
+    });
+
     id: TraceId;
 
     scoped<V>(callback: () => V): V;

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -25,8 +25,11 @@ class Tracer {
     // 64 and 128 bit incoming traces from upstream sources.
     traceId128Bit = false,
     localServiceName,
-    localEndpoint
+    localEndpoint,
+    /* eslint-disable no-console */
+    log = console
   }) {
+    this.log = log;
     this.recorder = recorder;
     this.sampler = sampler;
     this.traceId128Bit = traceId128Bit;
@@ -209,8 +212,7 @@ class Tracer {
   }
 
   writeIdToConsole(message) {
-    /* eslint-disable no-console */
-    console.log(`${message}: ${this.id.toString()}`);
+    this.log.info(`${message}: ${this.id.toString()}`);
   }
 }
 


### PR DESCRIPTION
Enables the application to pass a logging module as argument to be used instead of hardcoding to `console`, which will just print a string.

This is specially important for the transports, as production applications will likely use logging aggregation which will expect a specific format.

I was on the fence about updating the method `writeIdToConsole` in the `Tracer` class, but I did it for consistency.
