### PR TITLE
Support creating a new spanId on HttpServer instrumentation.

### DIFF
--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -118,6 +118,63 @@ describe('Http Server Instrumentation', () => {
     });
   });
 
+  traceContextCases.forEach((headers, index) => {
+    it(`should should not join spans if join not supported case ${index}`, () => {
+      const record = sinon.spy();
+      const recorder = {record};
+      const ctxImpl = new ExplicitContext();
+      const tracer = new Tracer({recorder, ctxImpl});
+
+      const port = 80;
+      const host = '127.0.0.1';
+      const url = `http://${host}:${port}`;
+      const instrumentation = new HttpServer({
+        tracer,
+        serviceName: 'service-a',
+        port,
+        supportsJoin: false
+      });
+
+      const readHeader = function(name) {
+        return headers[name] ? new Some(headers[name]) : None;
+      };
+      ctxImpl.scoped(() => {
+        const id = instrumentation.recordRequest('POST', url, readHeader);
+        tracer.recordBinary('message', 'hello from within app');
+        instrumentation.recordResponse(id, 202);
+      });
+      const annotations = record.args.map(args => args[0]);
+
+      annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
+      annotations.forEach(ann => expect(ann.traceId.parentId).to.equal('bbb'));
+      annotations.forEach(ann => expect(ann.traceId.spanId).to.not.equal('bbb'));
+
+      expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+      expect(annotations[0].annotation.serviceName).to.equal('service-a');
+
+      expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+      expect(annotations[1].annotation.name).to.equal('POST');
+
+      expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[2].annotation.key).to.equal('http.path');
+      expect(annotations[2].annotation.value).to.equal('/');
+
+      expect(annotations[3].annotation.annotationType).to.equal('ServerRecv');
+
+      expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
+
+      expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[5].annotation.key).to.equal('message');
+      expect(annotations[5].annotation.value).to.equal('hello from within app');
+
+      expect(annotations[6].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[6].annotation.key).to.equal('http.status_code');
+      expect(annotations[6].annotation.value).to.equal('202');
+
+      expect(annotations[7].annotation.annotationType).to.equal('ServerSend');
+    });
+  });
+
   const samplingFlagCases = [
         {headers: {'X-B3-Flags': '0'}, hasAnnotations: null},
         {headers: {'X-B3-Flags': '1'}, hasAnnotations: true},


### PR DESCRIPTION
Some tracing systems like Amazon X-Ray, Google Stackdriver Trace, LightStep or OpenTracing specification require each span to have a unique spanId, but currently using zipkin-js for tracing to those systems breaks the traces.

This change modifies the HttpServer instrumentation so that it is possible to force creation of a new id after reading the headers. It doesn't add support to other packages like express or hapi, but makes it easy to write a new server instrumentation with unique spanId support.