### PR TITLE
Add support for maxPayloadSize option in HttpLogger.

### DIFF
--- a/packages/zipkin-transport-http/test/integrationTest.js
+++ b/packages/zipkin-transport-http/test/integrationTest.js
@@ -84,9 +84,9 @@ describe('HTTP transport - integration test', () => {
     let publisherCount = 0;
     const maxPayloadSize = 1024;
     const app = mockPublisher((req) => {
-      const contentLength = parseInt(req.headers['content-length'], 10);
+      const contentLength = parseInt(req.headers['content-length']);
       expect(contentLength).to.be.below(maxPayloadSize);
-      if (++publisherCount == 2) {
+      if (++publisherCount === 2) {
         this.server.close(done);
       }
     });
@@ -100,11 +100,11 @@ describe('HTTP transport - integration test', () => {
         maxPayloadSize
       });
 
-      for (var i=0; i<6; i++) {
+      for (let i = 0; i < 6; i++) {
         triggerPublish(httpLogger);
       }
     });
-  })
+  });
 
   it('should emit an error when payload size is too large', function(done) {
     const self = this;
@@ -124,7 +124,7 @@ describe('HTTP transport - integration test', () => {
       httpLogger.on('error', () => { self.server.close(done); });
       triggerPublish(httpLogger);
     });
-  })
+  });
 
   it('should emit an error when an error listener is set', function(done) {
     const self = this;


### PR DESCRIPTION
Our problem is that having interval as the only way to control the data sent in HttpLogger is not acceptable for two reasons:
1. We have a limitation that our Zipkin server endpoint can only accept payloads up to a certain size
2. We want to reduce memory consumption of zipkin-js in cases where very large amounts of spans are sent in a short timeframe, which means we need to trigger a send earlier than the interval would otherwise trigger it

The solution is to add an option `maxPayloadSize` to HttpLogger, which will ensure that the send payload will never be larger than the set value in bytes. In case the queue plus the added span would go over the limit, the queue is flushed before the span is added to it. In case a single span itself would go over the limit, then the queue is flushed and the large span is dropped.