### PR TITLE
recoding default tags on server instrumentation

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -306,7 +306,13 @@ declare namespace zipkin {
 
   namespace Instrumentation {
     class HttpServer {
-      constructor(args: { tracer: Tracer, port: number });
+      constructor(args: {
+        tracer: Tracer,
+        port: number,
+        serviceName?: string,
+        host?: string,
+        serverTags?: {[key: string]: string}
+      });
 
       recordRequest(
         method: string,

--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -10,9 +10,11 @@ class HttpClientInstrumentation {
   constructor({
     tracer = requiredArg('tracer'),
     serviceName = tracer.localEndpoint.serviceName,
-    remoteServiceName
+    remoteServiceName,
+    clientTags = {}
   }) {
     this.tracer = tracer;
+    this.clientTags = clientTags;
     this.serviceName = serviceName;
     this.remoteServiceName = remoteServiceName;
   }
@@ -25,6 +27,11 @@ class HttpClientInstrumentation {
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
+
+    if (this.clientTags) {
+      this.tracer.setTags(this.clientTags);
+    }
+
     this.tracer.recordAnnotation(new Annotation.ClientSend());
     if (this.remoteServiceName) {
       // TODO: can we get the host and port of the http connection?

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -84,11 +84,8 @@ class HttpServerInstrumentation {
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const tag in this.serverTags) {
-      if (this.serverTags.hasOwnProperty(tag)) {
-        this.tracer.recordBinary(tag, this.serverTags[tag]);
-      }
+    if (this.serverTags) {
+      this.tracer.setTags(this.serverTags);
     }
 
     this.tracer.recordAnnotation(new Annotation.ServerRecv());

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -31,11 +31,13 @@ class HttpServerInstrumentation {
     serviceName = tracer.localEndpoint.serviceName,
     host,
     port = requiredArg('port'),
+    serverTags = {}
   }) {
     this.tracer = tracer;
     this.serviceName = serviceName;
     this.host = host && new InetAddress(host);
     this.port = port;
+    this.serverTags = serverTags;
   }
 
   _createIdFromHeaders(readHeader) {
@@ -81,6 +83,14 @@ class HttpServerInstrumentation {
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const tag in this.serverTags) {
+      if (this.serverTags.hasOwnProperty(tag)) {
+        this.tracer.recordBinary(tag, this.serverTags[tag]);
+      }
+    }
+
     this.tracer.recordAnnotation(new Annotation.ServerRecv());
     this.tracer.recordAnnotation(new Annotation.LocalAddr({host: this.host, port: this.port}));
 

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -220,6 +220,15 @@ class Tracer {
   writeIdToConsole(message) {
     this.log.info(`${message}: ${this.id.toString()}`);
   }
+
+  setTags(tags = {}) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const tag in tags) {
+      if (tags.hasOwnProperty(tag)) {
+        this.recordBinary(tag, tags[tag]);
+      }
+    }
+  }
 }
 
 module.exports = Tracer;

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -96,6 +96,29 @@ describe('Tracer', () => {
     });
   });
 
+  it('should record binary tags', () => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const localServiceName = 'smoothie-store';
+    const trace = new Tracer({ctxImpl, recorder, localServiceName});
+    const defaultTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
+
+    ctxImpl.scoped(() => {
+      trace.setTags(defaultTags);
+
+      const annotations = record.args.map(args => args[0]);
+
+      expect(annotations[0].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[0].annotation.key).to.equal('myTag');
+      expect(annotations[0].annotation.value).to.equal('some random stuff');
+
+      expect(annotations[1].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[1].annotation.key).to.equal('oneMore');
+      expect(annotations[1].annotation.value).to.equal('more random stuff');
+    });
+  });
+
   it('should complete a local span on error type', () => {
     const record = sinon.spy();
     const recorder = {record};


### PR DESCRIPTION
**What**: this is a simple change without contract break to allow the server instrumentation to save default tags at the creation time and record the tags with the request.

**Why**: this gives flexibility for users to set default tags they want recorded.

**The catch**: A few considerations:

1) I decided to send the tags at the constructor, because the `default tags` will already be available at the middleware bootstrap and decided to record them after the `http.path` tag for consistency.

2) why `for..in` instead of using a Map (and for..of) or iterate over the object keys? Well, using the following benchmark:

```javascript
var Benchmark = require('benchmark');
var util = require('util');
var suite = new Benchmark.Suite;


function record(key, val) {
    const x = {};
    x[key] = val;
}

suite.
add('forEach keys', function() {
    const obj = {
        foo: 'bar',
        banana: 'fruit',
        buick: 'car'
    };

    Object.keys(obj).forEach(tag => {
        record(tag, obj[tag]);
    });
}).
add('for..in', function() {
    const obj = {
        foo: 'bar',
        banana: 'fruit',
        buick: 'car'
    };

    for (const tag in obj) {
        if(obj.hasOwnProperty(tag)) {
            record(tag, obj[tag]);
        }
    }
}).
add('Map for..of', function() {
    const map = new Map();
    map.set('foo', 'bar');
    map.set('banana', 'fuit');
    map.set('buick', 'car');

    for (const [tag, value] of map) {
        record(tag, value);
    }
}).
on('cycle', function(event) {
    console.log(String(event.target));
}).
on('complete', function() {
    console.log('Fastest is ' + this.filter('fastest').map('name'));
}).
run();
```

I could verify that the `for..in` approach is 30% faster than the others. And because we must hit this middleware for all routes, performance counts.

cc/ @jcchavezs @adriancole 
