### PR TITLE
adding gRPC client instrumentation

### DIFF
--- a/packages/zipkin-instrumentation-grpc-client/.babelrc
+++ b/packages/zipkin-instrumentation-grpc-client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.babelrc"
+}

--- a/packages/zipkin-instrumentation-grpc-client/README.md
+++ b/packages/zipkin-instrumentation-grpc-client/README.md
@@ -1,0 +1,48 @@
+# zipkin-instrumentation-grpc-client
+
+[GRPC client](https://grpc.io/docs/tutorials/basic/node.html) interceptor for Zipkin.
+
+## Usage
+The library is a GRPC interceptor and can be used as:
+
+```javascript
+const grpc = require('grpc');
+const protoLoader = require('@grpc/proto-loader');
+
+const {Tracer, ExplicitContext, ConsoleRecorder} = require('zipkin');
+const grpcInstrumentation = require('zipkin-instrumentation-grpc-client');
+
+const PROTO_PATH = __dirname + '/protos/weather.proto';
+const PROTO_OPTIONS = { keepCase: true, enums: String, defaults: true, oneofs: true };
+
+// setup zipkin tracer
+const ctxImpl = new ExplicitContext();
+const recorder = new ConsoleRecorder();
+const localServiceName = 'service-a'; // name of this application
+const tracer = new Tracer({ctxImpl, recorder, localServiceName});
+
+// setup grpc client
+const definition = protoLoader.loadSync(PROTO_PATH, PROTO_OPTIONS);
+const weather = grpc.loadPackageDefinition(definition).weather;
+const client = new weather.WeatherService('localhost:50051', grpc.credentials.createInsecure());
+
+//setup interceptor
+const remoteServiceName = 'weather-service';
+const interceptor = grpcInstrumentation(grpc, {tracer, remoteServiceName});
+
+client.getTemperature({ location: 'Tahoe'}, { interceptors: [interceptor] }, (error, response) => {
+    console.info(`temprature in Tahoe is: ${response.temperature} `);
+});
+```
+
+The important snippet is:
+
+```javascript
+const interceptor = grpcInstrumentation(grpc, {tracer, remoteServiceName});
+
+client.getTemperature({ location: 'Tahoe'}, { interceptors: [interceptor] }, (error, response) => {
+    console.info(`temprature in Tahoe is: ${response.temperature} `);
+});
+
+``` 
+

--- a/packages/zipkin-instrumentation-grpc-client/package.json
+++ b/packages/zipkin-instrumentation-grpc-client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "zipkin-instrumentation-grpc-client",
+  "version": "0.14.3",
+  "description": "Zipking.js Interceptor for gRPC client",
+  "main": "lib/grpcClient.js",
+  "scripts": {
+    "build": "babel src -d lib",
+    "test": "mocha --require ../../test/helper.js",
+    "prepublish": "npm run build"
+  },
+  "author": "OpenZipkin <openzipkin.alt@gmail.com>",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/openzipkin/zipkin-js",
+  "devDependencies": {
+    "@babel/cli": "7.1.5",
+    "@babel/core": "7.1.5",
+    "express": "^4.13.4",
+    "mocha": "^5.2.0",
+    "zipkin": "^0.14.3",
+    "grpc": "^1.16.0",
+    "@grpc/proto-loader": "^0.3.0"
+  }
+}

--- a/packages/zipkin-instrumentation-grpc-client/src/grpcClientInstrumentation.js
+++ b/packages/zipkin-instrumentation-grpc-client/src/grpcClientInstrumentation.js
@@ -1,0 +1,116 @@
+const {Annotation, HttpHeaders} = require('zipkin');
+
+/**
+ * @private
+ * @param {string} name
+ * @throws Error
+ */
+function requiredArg(name) {
+  throw new Error(`GrpcClientInstrumentation: Missing required argument ${name}.`);
+}
+
+/**
+ * @namespace grpc
+ */
+
+/**
+ * @typedef {Object} grpc.Status
+ * @memberof grpc
+ * @property {function()} clone
+ * @property {function(key: string, value: string)} add
+ */
+
+/**
+ * @typedef {Object} grpc.Metadata
+ * @memberof grpc
+ * @property {function()} clone
+ * @property {function(key: string, value: string)} add
+ */
+
+/**
+ * @typedef {Object} GrpcClientContext
+ * @property {zipkin.Tracer} tracer
+ * @property {string} serviceName
+ * @property {string} remoteServiceName
+ */
+
+/**
+ * @class GrpcClientInstrumentation
+ */
+class GrpcClientInstrumentation {
+  /**
+   * @constructor
+   * @param {Object} grpc
+   * @param {GrpcClientContext} context
+   */
+  constructor(grpc, {
+    tracer = requiredArg('tracer'),
+    serviceName = tracer.localEndpoint.serviceName,
+    remoteServiceName
+  }) {
+    this.tracer = tracer;
+    this.serviceName = serviceName;
+    this.remoteServiceName = remoteServiceName;
+  }
+
+  /**
+   * Appends zipking headers to gRPC metadata
+   * @static
+   * @param {grpc.Metadata} originalMetadata
+   * @param {zipkin.TraceId} traceId
+   * @return {grpc.Metadata}
+   */
+  static setHeaders(originalMetadata, traceId) {
+    const metadata = originalMetadata.clone();
+    metadata.add(HttpHeaders.TraceId, traceId.traceId);
+    metadata.add(HttpHeaders.SpanId, traceId.spanId);
+
+    traceId._parentId.ifPresent(psid => {
+      metadata.add(HttpHeaders.ParentSpanId, psid);
+    });
+    traceId.sampled.ifPresent(sampled => {
+      metadata.add(HttpHeaders.Sampled, sampled ? '1' : '0');
+    });
+
+    return metadata;
+  }
+
+  /**
+   * Records start of RPC request
+   * @param {grpc.Metadata} metadata
+   * @param {string} method
+   * @return {grpc.Metadata}
+   */
+  start(metadata, method) {
+    this.tracer.setId(this.tracer.createChildId());
+    const traceId = this.tracer.id;
+
+    this.tracer.recordServiceName(this.serviceName);
+    this.tracer.recordRpc(method);
+    this.tracer.recordAnnotation(new Annotation.ClientSend());
+    if (this.remoteServiceName) {
+      this.tracer.recordAnnotation(new Annotation.ServerAddr({
+        serviceName: this.remoteServiceName
+      }));
+    }
+
+    return GrpcClientInstrumentation.setHeaders(metadata, traceId);
+  }
+
+  /**
+   * Records end of RPC request
+   * @param {zipkin.TraceId} traceId
+   * @param {grpc.Status} status
+   */
+  onReceiveStatus(traceId, status) {
+    const code = status.code.toString();
+    this.tracer.setId(traceId);
+    this.tracer.recordBinary('grpc.status_code', code);
+    if (code !== '0') {
+      this.tracer.recordBinary('error', code);
+    }
+    this.tracer.recordAnnotation(new Annotation.ClientRecv());
+  }
+}
+
+module.exports = GrpcClientInstrumentation;

--- a/packages/zipkin-instrumentation-grpc-client/src/grpcClientInterceptor.js
+++ b/packages/zipkin-instrumentation-grpc-client/src/grpcClientInterceptor.js
@@ -1,0 +1,55 @@
+/* eslint-disable new-cap,no-shadow */
+const Instrumentation = require('./grpcClientInstrumentation');
+
+/**
+ * @typedef {Object} InterceptorContext
+ * @property {zipkin.Tracer} tracer
+ * @property {string} serviceName
+ * @property {string} remoteServiceName
+ */
+
+/**
+ * @method
+ * @param {Object} grpc
+ * @param {InterceptorContext} context
+ * @returns {Interceptor}
+ */
+const interceptor = (grpc, {tracer, serviceName, remoteServiceName}) => {
+  const instrumentation = new Instrumentation(grpc, {tracer, serviceName, remoteServiceName});
+
+  /**
+   * @typedef {Function} Interceptor
+   * @param {Object} options
+   * @param {function()} nextCall
+   */
+  return (options, nextCall) => {
+    const method = options.method_definition.path;
+
+    return tracer.scoped(() =>
+      new grpc.InterceptingCall(nextCall(options), {
+        /**
+         * @param {grpc.Metadata} metadata
+         * @param {Object} listener
+         * @param {function(metadata: grpc.Metadata, listener: Object)} next
+         */
+        start(metadata, listener, next) {
+          const zipkinMetadata = instrumentation.start(metadata, method);
+          const traceId = tracer.id;
+
+          next(zipkinMetadata, {
+            /**
+             * @param {grpc.Status} status
+             * @param {function(status: grpc.Status)} next
+             */
+            onReceiveStatus(status, next) {
+              instrumentation.onReceiveStatus(traceId, status);
+              next(status);
+            }
+          });
+        }
+      })
+    );
+  };
+};
+
+module.exports = interceptor;

--- a/packages/zipkin-instrumentation-grpc-client/src/grpcClientInterceptor.js
+++ b/packages/zipkin-instrumentation-grpc-client/src/grpcClientInterceptor.js
@@ -4,7 +4,6 @@ const Instrumentation = require('./grpcClientInstrumentation');
 /**
  * @typedef {Object} InterceptorContext
  * @property {zipkin.Tracer} tracer
- * @property {string} serviceName
  * @property {string} remoteServiceName
  */
 
@@ -14,8 +13,8 @@ const Instrumentation = require('./grpcClientInstrumentation');
  * @param {InterceptorContext} context
  * @returns {Interceptor}
  */
-const interceptor = (grpc, {tracer, serviceName, remoteServiceName}) => {
-  const instrumentation = new Instrumentation(grpc, {tracer, serviceName, remoteServiceName});
+const interceptor = (grpc, {tracer, remoteServiceName}) => {
+  const instrumentation = new Instrumentation(grpc, {tracer, remoteServiceName});
 
   /**
    * @typedef {Function} Interceptor
@@ -33,8 +32,8 @@ const interceptor = (grpc, {tracer, serviceName, remoteServiceName}) => {
          * @param {function(metadata: grpc.Metadata, listener: Object)} next
          */
         start(metadata, listener, next) {
-          const zipkinMetadata = instrumentation.start(metadata, method);
-          const traceId = tracer.id;
+          const traceId = instrumentation.start(metadata, method);
+          const zipkinMetadata = Instrumentation.setHeaders(metadata, traceId);
 
           next(zipkinMetadata, {
             /**

--- a/packages/zipkin-instrumentation-grpc-client/test/.eslintrc
+++ b/packages/zipkin-instrumentation-grpc-client/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true
+  }
+}

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -1,0 +1,106 @@
+import uuid from 'uuid/v4';
+import CLSContext from 'zipkin-context-cls';
+import {Tracer} from 'zipkin';
+import sinon from 'sinon';
+import grpc from 'grpc';
+import grpcIntrumentation from '../src/grpcClientInterceptor';
+import {mockServer, getClient} from './utils';
+
+describe('gRPC client instrumentation (integration test)', () => {
+  const localServiceName = 'weather-client';
+  const remoteServiceName = 'weater-service';
+
+  let server;
+  before(() => {
+    server = mockServer();
+    server.start();
+  });
+
+  after(() => {
+    server.forceShutdown();
+  });
+
+  let record;
+  let recorder;
+  let ctxImpl;
+  let tracer;
+
+  beforeEach(() => {
+    record = sinon.spy();
+    recorder = {record};
+    ctxImpl = new CLSContext(`zipkin-test-${uuid()}`);
+    tracer = new Tracer({recorder, ctxImpl, localServiceName});
+  });
+
+  it('should record successful request', done => {
+    tracer.scoped(() => {
+      const client = getClient();
+      const interceptor = grpcIntrumentation(grpc, {tracer, remoteServiceName});
+      client.getTemperature({location: 'Tahoe'}, {interceptors: [interceptor]}, (err) => {
+        if (err) {
+          return done(err);
+        }
+
+        const annotations = record.args.map(args => args[0]);
+        const traceId = annotations[0].traceId.traceId;
+
+        annotations.forEach(annot => {
+          expect(annot.traceId.traceId).to.equal(traceId).and.to.have.lengthOf(16);
+        });
+
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal(localServiceName);
+
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('/weather.WeatherService/GetTemperature');
+
+        expect(annotations[2].annotation.annotationType).to.equal('ClientSend');
+
+        expect(annotations[3].annotation.annotationType).to.equal('ServerAddr');
+
+        expect(annotations[4].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[4].annotation.key).to.equal('grpc.status_code');
+        expect(annotations[4].annotation.value).to.equal('0');
+
+        expect(annotations[5].annotation.annotationType).to.equal('ClientRecv');
+        return done();
+      });
+    });
+  });
+
+  it('should record successful request', done => {
+    tracer.scoped(() => {
+      const client = getClient();
+      const interceptor = grpcIntrumentation(grpc, {tracer, remoteServiceName});
+      client.getTemperature({location: 'Las Vegas'}, {interceptors: [interceptor]}, () => {
+        const annotations = record.args.map(args => args[0]);
+        const traceId = annotations[0].traceId.traceId;
+
+        annotations.forEach(annot => {
+          expect(annot.traceId.traceId).to.equal(traceId).and.to.have.lengthOf(16);
+        });
+
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal(localServiceName);
+
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('/weather.WeatherService/GetTemperature');
+
+        expect(annotations[2].annotation.annotationType).to.equal('ClientSend');
+
+        expect(annotations[3].annotation.annotationType).to.equal('ServerAddr');
+
+        expect(annotations[4].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[4].annotation.key).to.equal('grpc.status_code');
+        expect(annotations[4].annotation.value).to.equal('2');
+
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('error');
+        expect(annotations[5].annotation.value).to.equal('2');
+
+        expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+        return done();
+      });
+    });
+  });
+});

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -58,11 +58,7 @@ describe('gRPC client instrumentation (integration test)', () => {
 
         expect(annotations[3].annotation.annotationType).to.equal('ServerAddr');
 
-        expect(annotations[4].annotation.annotationType).to.equal('BinaryAnnotation');
-        expect(annotations[4].annotation.key).to.equal('grpc.status_code');
-        expect(annotations[4].annotation.value).to.equal('0');
-
-        expect(annotations[5].annotation.annotationType).to.equal('ClientRecv');
+        expect(annotations[4].annotation.annotationType).to.equal('ClientRecv');
         return done();
       });
     });
@@ -99,6 +95,26 @@ describe('gRPC client instrumentation (integration test)', () => {
         expect(annotations[5].annotation.value).to.equal('2');
 
         expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+        return done();
+      });
+    });
+  });
+
+  it('should send "x-b3-flags" header', done => {
+    tracer.scoped(() => {
+      const client = getClient();
+
+      // enables debug
+      tracer.setId(tracer.createRootId(undefined, true));
+
+      const interceptor = grpcIntrumentation(grpc, {tracer, remoteServiceName});
+      client.getTemperature({location: 'Tahoe'}, {interceptors: [interceptor]}, (err, res) => {
+        if (err) {
+          return done(err);
+        }
+        const {metadata} = res;
+        // eslint-disable-next-line no-unused-expressions
+        expect(metadata['x-b3-flags']).to.equal('1');
         return done();
       });
     });

--- a/packages/zipkin-instrumentation-grpc-client/test/protos/weather.proto
+++ b/packages/zipkin-instrumentation-grpc-client/test/protos/weather.proto
@@ -12,5 +12,6 @@ message TemperatureRequest {
 
 message TemperatureReply {
     int32 temperature = 1;
+    map<string, string> metadata = 2;
 }
 

--- a/packages/zipkin-instrumentation-grpc-client/test/protos/weather.proto
+++ b/packages/zipkin-instrumentation-grpc-client/test/protos/weather.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package weather;
+
+service WeatherService {
+    rpc GetTemperature (TemperatureRequest) returns (TemperatureReply) {}
+}
+
+message TemperatureRequest {
+    string location = 1;
+}
+
+message TemperatureReply {
+    int32 temperature = 1;
+}
+

--- a/packages/zipkin-instrumentation-grpc-client/test/utils.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/utils.js
@@ -1,0 +1,54 @@
+/* eslint-disable new-cap */
+import {Tracer, ConsoleRecorder} from 'zipkin';
+import CLSContext from 'zipkin-context-cls';
+import uuid from 'uuid/v4';
+import grpc from 'grpc';
+import * as protoLoader from '@grpc/proto-loader';
+
+// constants
+const PROTO_PATH = `${__dirname}/protos/weather.proto`;
+const PROTO_OPTIONS = {keepCase: true, enums: String, defaults: true, oneofs: true};
+
+const definition = protoLoader.loadSync(PROTO_PATH, PROTO_OPTIONS);
+const weather = grpc.loadPackageDefinition(definition).weather;
+
+function getTemperature(call, callback) {
+  switch (call.request.location) {
+    case 'Las Vegas': return callback(new Error('test'));
+    case 'Tahoe': return callback(null, {temperature: '26'});
+    default: return callback(null, {temperature: '50'});
+  }
+}
+
+/**
+ * Tracer factory
+ * @return {zipkin.Tracer}
+ */
+const makeTracer = () => new Tracer({
+  ctxImpl: new CLSContext(`zipkin-test-${uuid()}`),
+  traceId128Bit: true,
+  recorder: new ConsoleRecorder(() => {}),
+});
+
+const tracer = makeTracer();
+const makeTraceId = () => tracer.createRootId();
+
+const mockServer = () => {
+  const server = new grpc.Server();
+  server.addService(weather.WeatherService.service, {
+    // here we map real methods to the proto service stubs
+    getTemperature
+  });
+  server.bind('0.0.0.0:50051', grpc.ServerCredentials.createInsecure());
+  return server;
+};
+
+const getClient = () =>
+  new weather.WeatherService('localhost:50051', grpc.credentials.createInsecure());
+
+export {
+  makeTracer,
+  makeTraceId,
+  mockServer,
+  getClient
+};

--- a/packages/zipkin-instrumentation-grpc-client/test/utils.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/utils.js
@@ -13,10 +13,11 @@ const definition = protoLoader.loadSync(PROTO_PATH, PROTO_OPTIONS);
 const weather = grpc.loadPackageDefinition(definition).weather;
 
 function getTemperature(call, callback) {
+  const metadata = call.metadata.getMap();
   switch (call.request.location) {
     case 'Las Vegas': return callback(new Error('test'));
-    case 'Tahoe': return callback(null, {temperature: '26'});
-    default: return callback(null, {temperature: '50'});
+    case 'Tahoe': return callback(null, {temperature: '26', metadata});
+    default: return callback(null, {temperature: '50', metadata});
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,16 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@grpc/proto-loader@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.3.0.tgz#c127d3859bff895f220453612ba04b923af0c584"
+  integrity sha512-9b8S/V+3W4Gv7G/JKSZ48zApgyYbfIR7mAC9XNnaSWme3zj57MIESu0ELzm9j5oxNIpFG8DgO00iJMIUZ5luqw==
+  dependencies:
+    "@types/lodash" "^4.14.104"
+    "@types/node" "^9.4.6"
+    lodash "^4.17.5"
+    protobufjs "^6.8.6"
+
 "@lerna/add@^3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.5.0.tgz#3518b3d4afc3743b7227b1ee3534114eb9575888"
@@ -1606,6 +1616,59 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
@@ -1698,6 +1761,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.104":
+  version "4.14.118"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
+
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
 "@types/mime-db@*":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@types/mime-db/-/mime-db-1.27.0.tgz#9bc014a1fd1fdf47649c1a54c6dd7966b8284792"
@@ -1720,10 +1793,15 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
   integrity sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==
 
-"@types/node@*":
+"@types/node@*", "@types/node@^10.1.0":
   version "10.12.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
   integrity sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==
+
+"@types/node@^9.4.6":
+  version "9.6.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.40.tgz#2d69cefbc090cb0bb824542a4c575b14dde7d3aa"
+  integrity sha512-M3HHoXXndsho/sTbQML2BJr7/uwNhMg8P0D4lb+UsM65JQZx268faiz9hKpY4FpocWqpwlLwa8vevw8hLtKjOw==
 
 "@types/podium@*":
   version "1.0.0"
@@ -1998,6 +2076,14 @@ asap@^2.0.0, asap@^2.0.6:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
+ascli@~1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
+  integrity sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=
+  dependencies:
+    colour "~0.7.1"
+    optjs "~3.2.2"
+
 asn1@0.1.11:
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.1.11.tgz#559be18376d08a4ec4dbe80877d27818639b2df7"
@@ -2221,6 +2307,11 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -2309,6 +2400,13 @@ byte-size@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-4.0.4.tgz#29d381709f41aae0d89c631f1c81aec88cd40b23"
   integrity sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==
+
+bytebuffer@~5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
+  dependencies:
+    long "~3"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -2411,7 +2509,7 @@ camelcase-keys@^4.0.0:
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
 
-camelcase@^2.0.0:
+camelcase@^2.0.0, camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
@@ -2579,6 +2677,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+cliui@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -2639,6 +2746,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colour@~0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
+  integrity sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -2658,6 +2770,13 @@ commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 commander@^2.12.1, commander@^2.8.1, commander@^2.9.0:
   version "2.19.0"
@@ -3015,6 +3134,13 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
+  dependencies:
+    ms "2.0.0"
+
 debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3056,7 +3182,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3185,6 +3311,11 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 diff@3.5.0, diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
@@ -4159,6 +4290,18 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -4222,10 +4365,30 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
+
+grpc@^1.16.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.1.tgz#533316f38cea68111ef577728c3f4e8e9e554543"
+  integrity sha512-7uHN1Nd3UqfvwgQ6f5U3+EZb/0iuHJ9mbPH+ydaTkszJsUi3nwdz6DuSh0eJwYVXXn6Gojv2khiQAadMongGKg==
+  dependencies:
+    lodash "^4.17.5"
+    nan "^2.0.0"
+    node-pre-gyp "^0.12.0"
+    protobufjs "^5.0.3"
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -4287,6 +4450,11 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -4589,6 +4757,11 @@ invariant@^2.2.0, invariant@^2.2.2:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -5009,6 +5182,11 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
+
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -5111,6 +5289,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
+  dependencies:
+    invert-kv "^1.0.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -5196,6 +5381,34 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5205,6 +5418,15 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
   integrity sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -5230,6 +5452,25 @@ lodash.get@~4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5277,6 +5518,16 @@ long@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/long/-/long-1.1.2.tgz#eaef5951ca7551d96926b82da242db9d6b28fb53"
   integrity sha1-6u9ZUcp1UdlpJrgtokLbnWso+1M=
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+long@~3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -5572,6 +5823,24 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+mocha@^3.2.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
+
 mocha@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
@@ -5650,7 +5919,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.10.0, nan@^2.11.0, nan@^2.9.2:
+nan@^2.0.0, nan@^2.10.0, nan@^2.11.0, nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
@@ -5800,6 +6069,22 @@ node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -6053,6 +6338,11 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+optjs@~3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
+  integrity sha1-aabOicRCpEQDFBrS+bNwvVu29O4=
+
 ora@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-1.4.0.tgz#884458215b3a5d4097592285f93321bb7a79e2e5"
@@ -6067,6 +6357,13 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
+  dependencies:
+    lcid "^1.0.0"
 
 os-locale@^3.0.0:
   version "3.0.1"
@@ -6585,6 +6882,35 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protobufjs@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
+  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
+  dependencies:
+    ascli "~1"
+    bytebuffer "~5"
+    glob "^7.0.5"
+    yargs "^3.10.0"
+
+protobufjs@^6.8.6:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
+  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
 
 protoduck@^5.0.1:
   version "5.0.1"
@@ -7830,6 +8156,13 @@ superagent@^4.0.0:
     qs "^6.5.1"
     readable-stream "^3.0.3"
 
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
+  dependencies:
+    has-flag "^1.0.0"
+
 supports-color@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
@@ -8419,6 +8752,11 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+window-size@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
+  integrity sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -8498,6 +8836,11 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
+y18n@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -8538,6 +8881,19 @@ yargs@^12.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^3.10.0:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  integrity sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
+    decamelize "^1.1.1"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"
 
 yarn@^1.3.2:
   version "1.12.3"


### PR DESCRIPTION
**What**: It creates a `grpc` node client interceptor, as [proposed here](https://github.com/grpc/proposal/blob/master/L5-node-client-interceptors.md) and in line with the current [API documentation](https://grpc.io/grpc/node/module-src_client_interceptors.html).

It keeps consistency with the other instrumentation packages in `zipkin-js`, where the tracing must be provided in order to create the interceptor. It will be up to the client generator to abstract it from the end user.

@adriancole please review the annotations and tags being recorded. Am I recording the same as in other languages?

@drobertduke please review it too. I based this work on the interceptors you sent me, but I might be missing something.

cc/ @jcchavezs 