### PR TITLE
send x-b3-flags header with http if debug is true

### DIFF
--- a/packages/zipkin/src/request.js
+++ b/packages/zipkin/src/request.js
@@ -12,6 +12,10 @@ function appendZipkinHeaders(req, traceId) {
     headers[HttpHeaders.Sampled] = sampled ? '1' : '0';
   });
 
+  if (traceId.isDebug()) {
+    headers[HttpHeaders.Flags] = '1';
+  }
+
   return headers;
 }
 

--- a/packages/zipkin/test/request.test.js
+++ b/packages/zipkin/test/request.test.js
@@ -28,4 +28,15 @@ describe('Request', () => {
     expect(req.headers[HttpHeaders.SpanId]).to.equal('48485a3953bb6124');
     expect(req.headers[HttpHeaders.ParentSpanId]).to.equal('d56852c923dc9325');
   });
+
+  it('should add flags headers if debug is on', () => {
+    const traceId = new TraceId({
+      spanId: '48485a3953bb6124',
+      flags: 1
+    });
+    const req = Request.addZipkinHeaders({}, traceId);
+
+    expect(req.headers[HttpHeaders.Flags]).to.equal('1');
+    expect(req.headers[HttpHeaders.SpanId]).to.equal('48485a3953bb6124');
+  });
 });


### PR DESCRIPTION
**Why**: on the [discussion about gRPC client](https://github.com/openzipkin/zipkin-js/pull/303#issuecomment-442940269), @jcchavezs brought to my attention I should be sending `X-B3-Flags` if debug is true. I later noticed http were not sending that header either.