### PR TITLE
Porting Zipkin package to TypeScript

### DIFF
--- a/packages/zipkin/.babelrc
+++ b/packages/zipkin/.babelrc
@@ -1,3 +1,6 @@
 {
-  "extends": "../../.babelrc"
+  "extends": "../../.babelrc",
+  "presets": [
+    "@babel/preset-typescript"
+  ]
 }

--- a/packages/zipkin/package.json
+++ b/packages/zipkin/package.json
@@ -5,8 +5,8 @@
   "main": "lib/index.js",
   "types": "index.d.ts",
   "scripts": {
-    "build": "babel src -d lib",
-    "test": "tsc index.d.ts && mocha --require ../../test/helper.js",
+    "build": "babel src -d lib --extensions \".ts\" --extensions \".js\"",
+    "test": "tsc index.d.ts && mocha --require ../../test/helper.js --require @babel/register",
     "prepublish": "npm run build"
   },
   "author": "OpenZipkin <openzipkin.alt@gmail.com>",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@babel/cli": "7.1.5",
     "@babel/core": "7.1.5",
+    "@babel/preset-typescript": "7.1.0",
     "bluebird": "^3.5.1",
     "mocha": "^5.2.0",
     "typescript": "^2.4.2"

--- a/packages/zipkin/src/index.ts
+++ b/packages/zipkin/src/index.ts
@@ -1,26 +1,26 @@
-import * as option from './option';
+import option from './option';
 
 import Annotation from './annotation';
 import Tracer from './tracer';
-const createNoopTracer = require('./tracer/noop');
-const randomTraceId = require('./tracer/randomTraceId');
-const TraceId = require('./tracer/TraceId');
-const sampler = require('./tracer/sampler');
+import createNoopTracer from './tracer/noop';
+import randomTraceId from './tracer/randomTraceId';
+import sampler from './tracer/sampler';
+import TraceId from './tracer/TraceId';
 
-const HttpHeaders = require('./httpHeaders');
-const InetAddress = require('./InetAddress');
+import HttpHeaders from './httpHeaders';
+import InetAddress from './InetAddress';
 
-const BatchRecorder = require('./batch-recorder');
-const ConsoleRecorder = require('./console-recorder');
+import BatchRecorder from './batch-recorder';
+import ConsoleRecorder from './console-recorder';
 
-const ExplicitContext = require('./explicit-context');
+import ExplicitContext from './explicit-context';
 
-const Request = require('./request');
-const Instrumentation = require('./instrumentation');
+import Instrumentation from './instrumentation';
+import Request from './request';
 
-const model = require('./model');
-const jsonEncoder = require('./jsonEncoder');
-const parseRequestUrl = require('./parseUrl');
+import jsonEncoder from './jsonEncoder';
+import model from './model';
+import parseRequestUrl from './parseUrl';
 
 module.exports = {
   Tracer,

--- a/packages/zipkin/src/index.ts
+++ b/packages/zipkin/src/index.ts
@@ -1,7 +1,7 @@
-const option = require('./option');
+import * as option from './option';
 
-const Annotation = require('./annotation');
-const Tracer = require('./tracer');
+import Annotation from './annotation';
+import Tracer from './tracer';
 const createNoopTracer = require('./tracer/noop');
 const randomTraceId = require('./tracer/randomTraceId');
 const TraceId = require('./tracer/TraceId');


### PR DESCRIPTION
Since #290 is too far behind from the master, I created a new branch so we can start fresh.
We had a problem on #290 that when building the lib, the file extensions weren't been deleted, so if we required a ts file on ```/src```, it will be required when built as well.
Doing some tests, looks like Import and Export statements do this for us, so I think we can do this in order to port zipkin package.