### PR TITLE
moving defaultTags to tracing (remove from http server and client)

### DIFF
--- a/packages/zipkin/src/instrumentation/httpClient.js
+++ b/packages/zipkin/src/instrumentation/httpClient.js
@@ -10,11 +10,9 @@ class HttpClientInstrumentation {
   constructor({
     tracer = requiredArg('tracer'),
     serviceName = tracer.localEndpoint.serviceName,
-    remoteServiceName,
-    clientTags = {}
+    remoteServiceName
   }) {
     this.tracer = tracer;
-    this.clientTags = clientTags;
     this.serviceName = serviceName;
     this.remoteServiceName = remoteServiceName;
   }
@@ -27,10 +25,6 @@ class HttpClientInstrumentation {
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
-
-    if (this.clientTags) {
-      this.tracer.setTags(this.clientTags);
-    }
 
     this.tracer.recordAnnotation(new Annotation.ClientSend());
     if (this.remoteServiceName) {

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -30,14 +30,12 @@ class HttpServerInstrumentation {
     tracer = requiredArg('tracer'),
     serviceName = tracer.localEndpoint.serviceName,
     host,
-    port = requiredArg('port'),
-    serverTags = {}
+    port = requiredArg('port')
   }) {
     this.tracer = tracer;
     this.serviceName = serviceName;
     this.host = host && new InetAddress(host);
     this.port = port;
-    this.serverTags = serverTags;
   }
 
   _createIdFromHeaders(readHeader) {
@@ -83,10 +81,6 @@ class HttpServerInstrumentation {
     this.tracer.recordServiceName(this.serviceName);
     this.tracer.recordRpc(method.toUpperCase());
     this.tracer.recordBinary('http.path', path);
-
-    if (this.serverTags) {
-      this.tracer.setTags(this.serverTags);
-    }
 
     this.tracer.recordAnnotation(new Annotation.ServerRecv());
     this.tracer.recordAnnotation(new Annotation.LocalAddr({host: this.host, port: this.port}));

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -32,7 +32,8 @@ class Tracer {
     localServiceName,
     localEndpoint,
     /* eslint-disable no-console */
-    log = console
+    log = console,
+    defaultTags
   }) {
     this.log = log;
     this.recorder = recorder;
@@ -50,6 +51,9 @@ class Tracer {
     this._defaultTraceId = this.createRootId();
     this._startTimestamp = now();
     this._startTick = hrtime();
+    if (defaultTags) {
+      this.setTags(defaultTags);
+    }
   }
 
   scoped(callback) {

--- a/packages/zipkin/test/httpClientInstrumentation.test.js
+++ b/packages/zipkin/test/httpClientInstrumentation.test.js
@@ -50,37 +50,6 @@ describe('Http Client Instrumentation', () => {
     expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
   });
 
-  it('should record default tags', () => {
-    const record = sinon.spy();
-    const recorder = {record};
-    const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({ctxImpl, recorder});
-    const url = 'http://127.0.0.1:80/weather?index=10&count=300';
-    const clientTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
-
-    const instrumentation = new HttpClient({
-      tracer,
-      clientTags,
-      serviceName: 'weather-app',
-      remoteServiceName: 'weather-forecast-service'
-    });
-
-    tracer.scoped(() => {
-      instrumentation.recordRequest({}, url, 'GET');
-      instrumentation.recordResponse(tracer.id, '202');
-    });
-
-    const annotations = record.args.map(args => args[0]);
-
-    expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[3].annotation.key).to.equal('myTag');
-    expect(annotations[3].annotation.value).to.equal('some random stuff');
-
-    expect(annotations[4].annotation.annotationType).to.equal('BinaryAnnotation');
-    expect(annotations[4].annotation.key).to.equal('oneMore');
-    expect(annotations[4].annotation.value).to.equal('more random stuff');
-  });
-
   it('should record an error', () => {
     const record = sinon.spy();
     const recorder = {record};

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -127,37 +127,6 @@ describe('Http Server Instrumentation', () => {
   });
 
   traceContextCases.forEach((headers, index) => {
-    it(`should record default tags ${index}`, () => {
-      const {record, recorder, ctxImpl} = setupTest();
-      const tracer = new Tracer({recorder, ctxImpl});
-
-      const {port, url} = setupServerUrl();
-      const serverTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
-      const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port, serverTags});
-
-      const readHeader = function(name) {
-        return headers[name] ? new Some(headers[name]) : None;
-      };
-      ctxImpl.scoped(() => {
-        const id = instrumentation.recordRequest('POST', url, readHeader);
-        instrumentation.recordResponse(id, 202);
-      });
-      const annotations = record.args.map(args => args[0]);
-
-      annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
-      annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
-
-      expect(annotations[3].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[3].annotation.key).to.equal('myTag');
-      expect(annotations[3].annotation.value).to.equal('some random stuff');
-
-      expect(annotations[4].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[4].annotation.key).to.equal('oneMore');
-      expect(annotations[4].annotation.value).to.equal('more random stuff');
-    });
-  });
-
-  traceContextCases.forEach((headers, index) => {
     it(`should should not join spans if join not supported case ${index}`, () => {
       const {record, recorder, ctxImpl} = setupTest();
       const tracer = new Tracer({recorder, ctxImpl, supportsJoin: false});

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -119,6 +119,28 @@ describe('Tracer', () => {
     });
   });
 
+  it('should record defaultTags', () => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    const localServiceName = 'smoothie-store';
+    const defaultTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
+    // eslint-disable-next-line no-unused-vars
+    const trace = new Tracer({ctxImpl, recorder, localServiceName, defaultTags});
+
+    ctxImpl.scoped(() => {
+      const annotations = record.args.map(args => args[0]);
+
+      expect(annotations[0].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[0].annotation.key).to.equal('myTag');
+      expect(annotations[0].annotation.value).to.equal('some random stuff');
+
+      expect(annotations[1].annotation.annotationType).to.equal('BinaryAnnotation');
+      expect(annotations[1].annotation.key).to.equal('oneMore');
+      expect(annotations[1].annotation.value).to.equal('more random stuff');
+    });
+  });
+
   it('should complete a local span on error type', () => {
     const record = sinon.spy();
     const recorder = {record};

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -102,7 +102,7 @@ describe('Tracer', () => {
     const ctxImpl = new ExplicitContext();
     const localServiceName = 'smoothie-store';
     const trace = new Tracer({ctxImpl, recorder, localServiceName});
-    const defaultTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
+    const defaultTags = {instanceId: 'i-1234567890abcdef0', cluster: 'nodeservice-stage'};
 
     ctxImpl.scoped(() => {
       trace.setTags(defaultTags);
@@ -110,12 +110,12 @@ describe('Tracer', () => {
       const annotations = record.args.map(args => args[0]);
 
       expect(annotations[0].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[0].annotation.key).to.equal('myTag');
-      expect(annotations[0].annotation.value).to.equal('some random stuff');
+      expect(annotations[0].annotation.key).to.equal('instanceId');
+      expect(annotations[0].annotation.value).to.equal('i-1234567890abcdef0');
 
       expect(annotations[1].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[1].annotation.key).to.equal('oneMore');
-      expect(annotations[1].annotation.value).to.equal('more random stuff');
+      expect(annotations[1].annotation.key).to.equal('cluster');
+      expect(annotations[1].annotation.value).to.equal('nodeservice-stage');
     });
   });
 
@@ -124,7 +124,7 @@ describe('Tracer', () => {
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
     const localServiceName = 'smoothie-store';
-    const defaultTags = {myTag: 'some random stuff', oneMore: 'more random stuff'};
+    const defaultTags = {instanceId: 'i-1234567890abcdef0', cluster: 'nodeservice-stage'};
     // eslint-disable-next-line no-unused-vars
     const trace = new Tracer({ctxImpl, recorder, localServiceName, defaultTags});
 
@@ -132,12 +132,12 @@ describe('Tracer', () => {
       const annotations = record.args.map(args => args[0]);
 
       expect(annotations[0].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[0].annotation.key).to.equal('myTag');
-      expect(annotations[0].annotation.value).to.equal('some random stuff');
+      expect(annotations[0].annotation.key).to.equal('instanceId');
+      expect(annotations[0].annotation.value).to.equal('i-1234567890abcdef0');
 
       expect(annotations[1].annotation.annotationType).to.equal('BinaryAnnotation');
-      expect(annotations[1].annotation.key).to.equal('oneMore');
-      expect(annotations[1].annotation.value).to.equal('more random stuff');
+      expect(annotations[1].annotation.key).to.equal('cluster');
+      expect(annotations[1].annotation.value).to.equal('nodeservice-stage');
     });
   });
 


### PR DESCRIPTION
removed defaultTags from http server and client instrumentation.

@jcchavezs let me know if this works for you...