### PR TITLE
fix: fixes lerna script for releasing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lerna-test": "lerna run test",
     "lerna-clean": "lerna clean",
     "lerna-build": "lerna run build",
-    "lerna-publish": "lerna publish --force-publish *",
+    "lerna-publish": "lerna publish",
     "postinstall": "yarn lerna-build"
   },
   "author": "OpenZipkin <openzipkin.alt@gmail.com>",


### PR DESCRIPTION
With the upgrade of lerna, this script for releasing got outdated. There is an [issue](https://github.com/openzipkin/zipkin-js/issues/316) to prevent this in the future.

Ping @ghermeto.