### PR TITLE
Fix express middleware - fixes #318

### DIFF
--- a/packages/zipkin-instrumentation-express/src/expressMiddleware.js
+++ b/packages/zipkin-instrumentation-express/src/expressMiddleware.js
@@ -48,6 +48,7 @@ module.exports = function expressMiddleware({tracer, serviceName, port = 0}) {
     }
 
     const id = instrumentation.recordRequest(req.method, formatRequestUrl(req), readHeader);
+    Object.defineProperty(req, '_trace_id', {configurable: false, get: () => id});
 
     res.on('finish', () => {
       tracer.scoped(() => {


### PR DESCRIPTION
**Why?** the tracer scoped inside the middleware was preventing the traceId to be accessed from sequential promises in the route handler.

@jcchavezs I added a test that verifies that the tracerId will remains the same within the same request, but will be different on subsequent requests.
