### PR TITLE
Do not send redis command payloads

### DIFF
--- a/packages/zipkin-instrumentation-redis/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-redis/src/zipkinClient.js
@@ -57,8 +57,9 @@ module.exports = function zipkinClient(
         clientNeedsToBeModified[method] = function(...args) {
           const multiInstance = actualFn.apply(this, args);
           const id = tracer.createChildId();
+          const commands = args[0].map(command => command[0]);
           tracer.letId(id, () => {
-            tracer.recordBinary('commands', JSON.stringify(args[0]));
+            tracer.recordBinary('commands', JSON.stringify(commands));
           });
           wrap(multiInstance, id);
           return multiInstance;

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -86,12 +86,12 @@ describe('redis interceptor', () => {
     redis.on('error', done);
     tracer.setId(tracer.createRootId());
     redis.set('ping', 'pong', 10, () => {
-      redis.batch([['get', 'ping']]).exec(() => {
+      redis.batch([['get', 'ping'], ['set', 'syn', 'ack']]).exec(() => {
         const annotations = recorder.record.args.map(args => args[0]);
         const firstAnn = annotations[0];
         expect(annotations).to.have.length(11);
         expect(annotations[5].annotation.key).to.equal('commands');
-        expect(annotations[5].annotation.value).to.deep.equal('[["get","ping"]]');
+        expect(annotations[5].annotation.value).to.deep.equal('["get","set"]');
         expect(annotations[6].annotation.name).to.equal('exec');
 
         // we expect two spans, run annotations tests for each


### PR DESCRIPTION
The tracing of single commands do not record the payload but batched commands include it.

For many commands with big payloads this can end up becoming several megabytes of annotation information.

This commit removes it for batched commands as well.