### PR TITLE
Updated main file in package zipkin-instrumentation-grpc-client

### DIFF
--- a/packages/zipkin-instrumentation-grpc-client/package.json
+++ b/packages/zipkin-instrumentation-grpc-client/package.json
@@ -2,7 +2,7 @@
   "name": "zipkin-instrumentation-grpc-client",
   "version": "0.15.0",
   "description": "Zipking.js Interceptor for gRPC client",
-  "main": "lib/grpcClient.js",
+  "main": "lib/grpcClientInterceptor.js",
   "scripts": {
     "build": "babel src -d lib",
     "test": "mocha --require ../../test/helper.js",


### PR DESCRIPTION
 I had included zipkin-instrumentation-grpc-client using npm install

`npm install zipkin-instrumentation-grpc-client@0.15.0 --save`

On running the application, I get the error
`Error: Cannot find module 'zipkin-instrumentation-grpc-client' at Function.Module._resolveFilename (module.js:547:15) at Function.Module._load (module.js:474:25) at Module.require (module.js:596:17) at require (internal/module.js:11:18) at Object.<anonymous> (/Users/300027553/Work/wit/mwpserver/server/grpc/client/workouts.js:5:1) at Module._compile (module.js:652:30) at loader (/Users/300027553/Work/wit/mwpserver/node_modules/babel-register/lib/node.js:144:5) at Object.require.extensions.(anonymous function) [as .js] (/Users/300027553/Work/wit/mwpserver/node_modules/babel-register/lib/node.js:154:7) at Module.load (module.js:565:32) at tryModuleLoad (module.js:505:12) at Function.Module._load (module.js:497:3) at Module.require (module.js:596:17) at require (internal/module.js:11:18)`

This is because in package.json, the main file points to lib/grpcClient.js.

But there is no such file.

I have updated the package.json to point to the right file