### PR TITLE
Upgraded the node-fetch version to 2.3.0 in zipkin-transport-http

### DIFF
--- a/packages/zipkin-transport-http/package.json
+++ b/packages/zipkin-transport-http/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "node-fetch": "^1.5.3"
+    "node-fetch": "^2.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",


### PR DESCRIPTION
Upgraded the node-fetch version to 2.3.0 in zipkin-transport-http.
We are getting build warning  from react application because of this old dependency.