### PR TITLE
Fix fetch signature

### DIFF
--- a/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
+++ b/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
@@ -4,9 +4,10 @@ const {
 
 function wrapFetch(fetch, {tracer, serviceName, remoteServiceName}) {
   const instrumentation = new Instrumentation.HttpClient({tracer, serviceName, remoteServiceName});
-  return function zipkinfetch(url, opts = {}) {
+  return function zipkinfetch(input, opts = {}) {
     return new Promise((resolve, reject) => {
       tracer.scoped(() => {
+        const url = (typeof input === 'string') ? input : input.url;
         const method = opts.method || 'GET';
         const zipkinOpts =
           instrumentation.recordRequest(opts, url, method);

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -84,13 +84,26 @@ describe('wrapFetch', () => {
     });
   });
 
-
   it('should not throw when using fetch without options', function(done) {
     const tracer = createNoopTracer();
     const fetch = wrapFetch(nodeFetch, {serviceName: 'user-service', tracer});
 
     const path = `http://127.0.0.1:${this.port}/user`;
     fetch(path)
+      .then(res => res.json())
+      .then(() => {
+        done();
+      })
+      .catch(done);
+  });
+
+  it('should not throw when using fetch with a request object', function(done) {
+    const tracer = createNoopTracer();
+    const fetch = wrapFetch(nodeFetch, {serviceName: 'user-service', tracer});
+
+    const path = `http://127.0.0.1:${this.port}/user`;
+    const request = {url: path};
+    fetch(request)
       .then(res => res.json())
       .then(() => {
         done();


### PR DESCRIPTION
The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) defines the first argument as being either of the type `USVString` or `Request`. The current implementation of `zipkin-instrumentation-fetch` however only accepts a string; causing a `TypeError` to be thrown if a `Request` is passed.