### PR TITLE
Fix the browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-builtins": "^2.1.2",
+    "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^3.0.0",

--- a/packages/zipkin/rollup.config.js
+++ b/packages/zipkin/rollup.config.js
@@ -3,6 +3,7 @@ import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import {terser} from 'rollup-plugin-terser';
+import globals from 'rollup-plugin-node-globals';
 import builtins from 'rollup-plugin-node-builtins';
 
 const basePlugins = [
@@ -45,6 +46,7 @@ export default [
       replace({
         'process.env.NODE_ENV': JSON.stringify('development')
       }),
+      globals(),
       builtins(),
     ]),
   },
@@ -69,6 +71,7 @@ export default [
           warnings: false
         }
       }),
+      globals(),
       builtins(),
     ]),
   }

--- a/packages/zipkin/src/index.ts
+++ b/packages/zipkin/src/index.ts
@@ -1,43 +1,23 @@
-import option from './option';
+export { default as option } from './option';
 
-import Annotation from './annotation';
-import Tracer from './tracer';
-import createNoopTracer from './tracer/noop';
-import randomTraceId from './tracer/randomTraceId';
-import sampler from './tracer/sampler';
-import TraceId from './tracer/TraceId';
+export { default as Annotation } from './annotation';
+export { default as Tracer } from './tracer';
+export { default as createNoopTracer } from './tracer/noop';
+export { default as randomTraceId } from './tracer/randomTraceId';
+export { default as sampler } from './tracer/sampler';
+export { default as TraceId } from './tracer/TraceId';
 
-import HttpHeaders from './httpHeaders';
-import InetAddress from './InetAddress';
+export { default as HttpHeaders } from './httpHeaders';
+export { default as InetAddress } from './InetAddress';
 
-import BatchRecorder from './batch-recorder';
-import ConsoleRecorder from './console-recorder';
+export { default as BatchRecorder } from './batch-recorder';
+export { default as ConsoleRecorder } from './console-recorder';
 
-import ExplicitContext from './explicit-context';
+export { default as ExplicitContext } from './explicit-context';
 
-import Instrumentation from './instrumentation';
-import Request from './request';
+export { default as Instrumentation } from './instrumentation';
+export { default as Request } from './request';
 
-import jsonEncoder from './jsonEncoder';
-import model from './model';
-import parseRequestUrl from './parseUrl';
-
-module.exports = {
-  Tracer,
-  createNoopTracer,
-  randomTraceId,
-  TraceId,
-  option,
-  Annotation,
-  InetAddress,
-  HttpHeaders,
-  BatchRecorder,
-  ConsoleRecorder,
-  ExplicitContext,
-  sampler,
-  Request,
-  Instrumentation,
-  model,
-  jsonEncoder,
-  parseRequestUrl
-};
+export { default as jsonEncoder } from './jsonEncoder';
+export { default as model } from './model';
+export { default as parseRequestUrl } from './parseUrl';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,7 +1939,7 @@ acorn@^3.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^5.5.0:
+acorn@^5.5.0, acorn@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -2626,7 +2626,7 @@ buffer-crc32@~0.2.5:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-buffer-es6@^4.9.2:
+buffer-es6@^4.9.2, buffer-es6@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/buffer-es6/-/buffer-es6-4.9.3.tgz#f26347b82df76fd37e18bcb5288c4970cfd5c404"
   integrity sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=
@@ -6533,6 +6533,13 @@ ltgt@^2.1.2:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
 
+magic-string@^0.22.5:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
+  dependencies:
+    vlq "^0.2.2"
+
 magic-string@^0.25.1:
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.1.tgz#b1c248b399cd7485da0fe7385c2fc7011843266e"
@@ -7080,6 +7087,11 @@ node-fetch@^1.5.3:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -7995,7 +8007,7 @@ private@^0.1.6:
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
 
-process-es6@^0.11.2:
+process-es6@^0.11.2, process-es6@^0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/process-es6/-/process-es6-0.11.6.tgz#c6bb389f9a951f82bd4eb169600105bd2ff9c778"
   integrity sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g=
@@ -8771,6 +8783,18 @@ rollup-plugin-node-builtins@^2.1.2:
     crypto-browserify "^3.11.0"
     process-es6 "^0.11.2"
 
+rollup-plugin-node-globals@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.4.0.tgz#5e1f24a9bb97c0ef51249f625e16c7e61b7c020b"
+  integrity sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==
+  dependencies:
+    acorn "^5.7.3"
+    buffer-es6 "^4.9.3"
+    estree-walker "^0.5.2"
+    magic-string "^0.22.5"
+    process-es6 "^0.11.6"
+    rollup-pluginutils "^2.3.1"
+
 rollup-plugin-node-resolve@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz#908585eda12e393caac7498715a01e08606abc89"
@@ -8799,7 +8823,7 @@ rollup-plugin-terser@^3.0.0:
     serialize-javascript "^1.5.0"
     terser "^3.8.2"
 
-rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.3:
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
   integrity sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==
@@ -10244,6 +10268,11 @@ vise@2.x.x:
   integrity sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=
   dependencies:
     hoek "4.x.x"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 vm-browserify@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This PR fixes the Zipkin bundle execution in the browser. The current bundle has two main issues:

* it is using the `global` variable, which isn't (yet) defined in browsers
* it is exporting the Zipkin values using `module.exports`.

See: https://jsbin.com/wuzeqetezi/edit?html,output