### PR TITLE
allow id generators to be passed to the tracer (#209)

### DIFF
--- a/packages/zipkin/src/index.ts
+++ b/packages/zipkin/src/index.ts
@@ -3,7 +3,7 @@ export { default as option } from './option';
 export { default as Annotation } from './annotation';
 export { default as Tracer } from './tracer';
 export { default as createNoopTracer } from './tracer/noop';
-export { default as randomTraceId } from './tracer/randomTraceId';
+export { randomTraceId, randomTraceId128bit } from './tracer/randomTraceId';
 export { default as sampler } from './tracer/sampler';
 export { default as TraceId } from './tracer/TraceId';
 

--- a/packages/zipkin/src/tracer/randomTraceId.js
+++ b/packages/zipkin/src/tracer/randomTraceId.js
@@ -1,5 +1,5 @@
 // === Generate a random 64-bit number in fixed-length hex format
-function randomTraceId() {
+export function randomTraceId() {
   const digits = '0123456789abcdef';
   let n = '';
   for (let i = 0; i < 16; i++) {
@@ -9,4 +9,6 @@ function randomTraceId() {
   return n;
 }
 
-module.exports = randomTraceId;
+export function randomTraceId128bit() {
+  return randomTraceId() + randomTraceId();
+}

--- a/packages/zipkin/test-types/randomTraceId.test.ts
+++ b/packages/zipkin/test-types/randomTraceId.test.ts
@@ -1,10 +1,20 @@
 import { expect } from 'chai';
-import { randomTraceId } from 'zipkin';
+import { randomTraceId, randomTraceId128bit } from 'zipkin';
 
-describe('RandomTraceId', () => {
-  it('should return string', () => {
-    const rand = randomTraceId();
+describe('trace id generation', () => {
+  describe('#randomTraceId', () => {
+    it('should return string', () => {
+      const rand = randomTraceId();
 
-    expect(rand).to.be.a('string');
+      expect(rand).to.be.a('string');
+    });
+  });
+
+  describe('#randomTraceId128bit', () => {
+    it('should return string', () => {
+      const rand = randomTraceId128bit();
+
+      expect(rand).to.be.a('string');
+    });
   });
 });

--- a/packages/zipkin/test/randomTraceId.test.js
+++ b/packages/zipkin/test/randomTraceId.test.js
@@ -1,10 +1,20 @@
-const randomTraceId = require('../src/tracer/randomTraceId');
+const {randomTraceId, randomTraceId128bit} = require('../src/tracer/randomTraceId');
 
-describe('random trace id', () => {
-  it('should have fixed length of 16 characters', () => {
-    for (let i = 0; i < 100; i++) {
-      const rand = randomTraceId();
-      expect(rand.length).to.equal(16);
-    }
+describe('trace id generation', () => {
+  describe('#randomTraceId', () => {
+    it('should have fixed length of 16 characters', () => {
+      for (let i = 0; i < 100; i++) {
+        const rand = randomTraceId();
+        expect(rand.length).to.equal(16);
+      }
+    });
+  });
+  describe('#randomTraceId128bit', () => {
+    it('should have fixed length of 32 characters', () => {
+      for (let i = 0; i < 100; i++) {
+        const rand = randomTraceId128bit();
+        expect(rand.length).to.equal(32);
+      }
+    });
   });
 });

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -408,4 +408,32 @@ describe('Tracer', () => {
     const rootTracerId = tracer.createRootId();
     expect(rootTracerId.traceId.length).to.eql(32);
   });
+
+  it('should accept the spanId generation algorithm', () => {
+    const recorder = {
+      record: () => {}
+    };
+    const ctxImpl = new ExplicitContext();
+    const generateSpanId = sinon.spy(() => 'notsorandomspanid');
+    const tracer = new Tracer({ctxImpl, recorder, generateSpanId});
+
+    const rootTracerId = tracer.createRootId();
+
+    expect(generateSpanId.called).to.equal(true);
+    expect(rootTracerId._spanId).to.equal('notsorandomspanid');
+  });
+
+  it('should accept the traceId generation algorithm', () => {
+    const recorder = {
+      record: () => {}
+    };
+    const ctxImpl = new ExplicitContext();
+    const generateTraceId = sinon.spy(() => 'notsorandomtraceid');
+    const tracer = new Tracer({ctxImpl, recorder, generateTraceId});
+
+    const rootTracerId = tracer.createRootId();
+
+    expect(generateTraceId.called).to.equal(true);
+    expect(rootTracerId._traceId.getOrElse('')).to.equal('notsorandomtraceid');
+  });
 });


### PR DESCRIPTION
This PR tries to address the issue #209.

The tracer now defines two extra optional function parameters, the traceId generator function and the spanId generator function. The spanId generator parameter defaults to the `randomTraceId` function that we were already using. The traceId generator parameter defaults to a new `randomTraceId128bit` function that mimics the current behaviour: `randomTraceId() + randomTraceId()`.

I am not sure this is the best approach but it is the best solution I could find without breaking the API or changing the current behaviour. I lack the deep understanding of zipkin to feel comfortable making deeper changes, so any suggestions will be welcomed 😄

cheers!