### PR TITLE
Adds support for node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,20 @@ matrix:
         - TEST_SUITE=browser
       addons:
         chrome: stable
+        
+    - node_js: 9
+      env:
+        - CXX=clang-3.6
+        - KAFKA_PLEASE_LOG=verbose
+        - TEST_SUITE=nodejs
+
+    - name: 'browser'
+      node_js: 9
+      env:
+        - CXX=clang-3.6
+        - TEST_SUITE=browser
+      addons:
+        chrome: stable
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5


### PR DESCRIPTION
This PR enables our CI to run tests in node 9. Should we skip support for this and try with node 10?

Ping @openzipkin/zipkin-js-champions @ghermeto 