### PR TITLE
chore(#338): Removes support for node 6 in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ sudo: required
 
 matrix:
   include:
-    - node_js: 6
-      env:
-        - CXX=clang-3.6
-        - KAFKA_PLEASE_LOG=verbose
-        - TEST_SUITE=nodejs
-
     - node_js: 8
       env:
         - CXX=clang-3.6


### PR DESCRIPTION
Comes from #338 

Ping @openzipkin/zipkin-js-champions 