### PR TITLE
#348 pass traceId from request to response

### DIFF
--- a/packages/zipkin-instrumentation-axios/src/index.js
+++ b/packages/zipkin-instrumentation-axios/src/index.js
@@ -3,7 +3,20 @@ import {Instrumentation} from 'zipkin';
 export const wrapAxios = (axios, options = {}) => {
   const {tracer} = options;
   const instrumentation = new Instrumentation.HttpClient(options);
-  const zipkinRecordError = error => {
+  const zipkinRecordRequest = config => tracer.scoped(() => {
+    const newConfig = instrumentation.recordRequest(
+        config,
+        config.url,
+        config.method
+      );
+    newConfig.traceId = tracer.id;
+    return newConfig;
+  });
+  const zipkinRecordResponse = res => tracer.scoped(() => {
+    instrumentation.recordResponse(res.config.traceId, res.status);
+    return res;
+  });
+  const zipkinRecordError = error => tracer.scoped(() => {
     const traceId = error.config.traceId;
     if (error.response) {
       instrumentation.recordResponse(traceId, error.response.status);
@@ -11,20 +24,7 @@ export const wrapAxios = (axios, options = {}) => {
       instrumentation.recordError(traceId, error);
     }
     return Promise.reject(error);
-  };
-  const zipkinRecordRequest = config => {
-    const newConfig = instrumentation.recordRequest(
-      config,
-      config.url,
-      config.method
-    );
-    newConfig.traceId = tracer.id;
-    return newConfig;
-  };
-  const zipkinRecordResponse = res => {
-    instrumentation.recordResponse(res.config.traceId, res.status);
-    return res;
-  };
+  });
   let axiosInstance = axios;
   if (axios.create) {
     axiosInstance = axios.create();

--- a/packages/zipkin-instrumentation-axios/src/index.js
+++ b/packages/zipkin-instrumentation-axios/src/index.js
@@ -1,28 +1,42 @@
 import {Instrumentation} from 'zipkin';
-const zipkinRecordError = (error, options) => {
-  const instrumentation = new Instrumentation.HttpClient(options);
-  if (error.response) {
-    instrumentation.recordResponse(options.tracer.id, error.response.status);
-  } else {
-    instrumentation.recordError(options.tracer.id, error);
-  }
-  return Promise.reject(error);
-};
-const zipkinRecordRequest = (config, options) => {
-  const instrumentation = new Instrumentation.HttpClient(options);
-  return instrumentation.recordRequest(config, config.url, config.method);
-};
-const zipkinRecordResponse = (res, options) => {
-  const instrumentation = new Instrumentation.HttpClient(options);
-  instrumentation.recordResponse(options.tracer.id, res.status);
-  return res;
-};
 
-const wrapAxios = (axios, options = {}) => {
-  axios.interceptors.request.use(config => zipkinRecordRequest(config, options),
-      err => zipkinRecordError(err, options));
-  axios.interceptors.response.use(res => zipkinRecordResponse(res, options),
-      err => zipkinRecordError(err, options));
-  return axios;
+export const wrapAxios = (axios, options = {}) => {
+  const {tracer} = options;
+  const instrumentation = new Instrumentation.HttpClient(options);
+  const zipkinRecordError = error => {
+    const traceId = error.config.traceId;
+    if (error.response) {
+      instrumentation.recordResponse(traceId, error.response.status);
+    } else {
+      instrumentation.recordError(traceId, error);
+    }
+    return Promise.reject(error);
+  };
+  const zipkinRecordRequest = config => {
+    const newConfig = instrumentation.recordRequest(
+      config,
+      config.url,
+      config.method
+    );
+    newConfig.traceId = tracer.id;
+    return newConfig;
+  };
+  const zipkinRecordResponse = res => {
+    instrumentation.recordResponse(res.config.traceId, res.status);
+    return res;
+  };
+  let axiosInstance = axios;
+  if (axios.create) {
+    axiosInstance = axios.create();
+  }
+  axiosInstance.interceptors.request.use(
+    config => zipkinRecordRequest(config),
+    err => zipkinRecordError(err)
+  );
+  axiosInstance.interceptors.response.use(
+    res => zipkinRecordResponse(res),
+    err => zipkinRecordError(err)
+  );
+  return axiosInstance;
 };
 export default wrapAxios;

--- a/packages/zipkin-instrumentation-axios/src/index.js
+++ b/packages/zipkin-instrumentation-axios/src/index.js
@@ -29,14 +29,8 @@ export const wrapAxios = (axios, options = {}) => {
   if (axios.create) {
     axiosInstance = axios.create();
   }
-  axiosInstance.interceptors.request.use(
-    config => zipkinRecordRequest(config),
-    err => zipkinRecordError(err)
-  );
-  axiosInstance.interceptors.response.use(
-    res => zipkinRecordResponse(res),
-    err => zipkinRecordError(err)
-  );
+  axiosInstance.interceptors.request.use(zipkinRecordRequest, zipkinRecordError);
+  axiosInstance.interceptors.response.use(zipkinRecordResponse, zipkinRecordError);
   return axiosInstance;
 };
 export default wrapAxios;

--- a/packages/zipkin-instrumentation-axios/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axios/test/integrationTest.js
@@ -1,9 +1,9 @@
 import {Tracer, ExplicitContext} from 'zipkin';
-import express from 'express';
 import axios from 'axios';
 import sinon from 'sinon';
 import {expect} from 'chai';
 import wrapAxios from '../src/index';
+import {mockServer} from './utils';
 
 describe('axios instrumentation - integration test', () => {
   const serviceName = 'weather-app';
@@ -15,32 +15,8 @@ describe('axios instrumentation - integration test', () => {
   let record;
   let tracer;
   before((done) => {
-    const api = express();
-    api.get('/weather/wuhan', (req, res) => {
-      res.status(202).json({
-        traceId: req.header('X-B3-TraceId'),
-        spanId: req.header('X-B3-SpanId')
-      });
-    });
-    api.get('/weather/beijing', (req, res) => {
-      res.status(202).json({
-        traceId: req.header('X-B3-TraceId'),
-        spanId: req.header('X-B3-SpanId')
-      });
-    });
-    api.get('/weather/securedTown', (req, res) => {
-      res.status(400).json({
-        traceId: req.header('X-B3-TraceId'),
-        spanId: req.header('X-B3-SpanId')
-      });
-    });
-    api.get('/weather/bagCity', (req, res) => {
-      res.status(500).json({
-        traceId: req.header('X-B3-TraceId'),
-        spanId: req.header('X-B3-SpanId')
-      });
-    });
-    apiServer = api.listen(0, () => {
+    mockServer().then(server => {
+      apiServer = server;
       apiPort = apiServer.address().port;
       apiHost = '127.0.0.1';
       done();

--- a/packages/zipkin-instrumentation-axios/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axios/test/integrationTest.js
@@ -9,10 +9,20 @@ describe('axios instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let api;
-  before(() => {
-    api = express();
-    api.get('/weather', (req, res) => {
+  let apiServer;
+  let apiHost;
+  let apiPort;
+  let record;
+  let tracer;
+  before((done) => {
+    const api = express();
+    api.get('/weather/wuhan', (req, res) => {
+      res.status(202).json({
+        traceId: req.header('X-B3-TraceId'),
+        spanId: req.header('X-B3-SpanId')
+      });
+    });
+    api.get('/weather/beijing', (req, res) => {
       res.status(202).json({
         traceId: req.header('X-B3-TraceId'),
         spanId: req.header('X-B3-SpanId')
@@ -30,27 +40,28 @@ describe('axios instrumentation - integration test', () => {
         spanId: req.header('X-B3-SpanId')
       });
     });
+    apiServer = api.listen(0, () => {
+      apiPort = apiServer.address().port;
+      apiHost = '127.0.0.1';
+      done();
+    });
   });
-
-  let record;
-  let recorder;
-  let ctxImpl;
-  let tracer;
+  after(() => {
+    apiServer.close();
+  });
+  const getClient = () => wrapAxios(axios, {tracer, serviceName, remoteServiceName});
   beforeEach(() => {
     record = sinon.spy();
-    recorder = {record};
-    ctxImpl = new ExplicitContext();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
     tracer = new Tracer({recorder, ctxImpl});
   });
   it('should add headers to requests', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather';
-        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
-        zipkinAxios
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/wuhan';
+      const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
+      zipkinAxiosClient
           .get(url)
           .then(() => {
             const annotations = record.args.map(args => args[0]);
@@ -80,57 +91,49 @@ describe('axios instrumentation - integration test', () => {
             expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
             done();
           });
-      });
     });
   });
   it('should support request shorthand (defaults to GET)', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather';
-        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
-        zipkinAxios.get(url).then(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/wuhan';
+      const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
+      zipkinAxiosClient.get(url).then(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal(urlPath);
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
-          done();
-        });
+        expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+        done();
       });
     });
   });
   it('should support both url and uri options', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather';
-        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
-        zipkinAxios({url})
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/wuhan';
+      const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
+      zipkinAxiosClient({url})
           .then(() => {
             const annotations = record.args.map(args => args[0]);
             const initialTraceId = annotations[0].traceId.traceId;
@@ -159,91 +162,82 @@ describe('axios instrumentation - integration test', () => {
             expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
             done();
           });
-      });
     });
   });
   it('should support promise callback', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather';
-        const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
-        zipkinAxios({url}).then(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/wuhan';
+      const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
+      zipkinAxiosClient({url}).then(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal(urlPath);
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('202');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('202');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
-          done();
-        });
+        expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+        done();
       });
     });
   });
 
   it('should report 404 when path does not exist', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/doesNotExist';
-        const url = `http://${apiHost}:${apiPort}${urlPath}`;
-        zipkinAxios({url, timeout: 100}).catch(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/doesNotExist';
+      const url = `http://${apiHost}:${apiPort}${urlPath}`;
+      zipkinAxiosClient({url, timeout: 100}).catch(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal(urlPath);
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('404');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('404');
 
-          expect(annotations[6].annotation.key).to.equal('error');
-          expect(annotations[6].annotation.value).to.equal('404');
+        expect(annotations[6].annotation.key).to.equal('error');
+        expect(annotations[6].annotation.value).to.equal('404');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+        expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+        expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
 
-          done();
-        });
+        done();
       });
     });
   });
@@ -252,132 +246,215 @@ describe('axios instrumentation - integration test', () => {
   it('should report when service does not exist', function(done) {
     this.timeout(1000); // Wait long than request timeout
     tracer.scoped(() => {
-      api.listen(0, () => {
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const host = 'localhost:12345';
-        const url = `http://${host}`;
-        zipkinAxios({url, timeout: 200}).catch(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const host = 'localhost:12345';
+      const url = `http://${host}`;
+      zipkinAxiosClient({url, timeout: 200}).catch(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal('/');
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal('/');
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('error');
-          expect(annotations[5].annotation.value)
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('error');
+        expect(annotations[5].annotation.value)
             .to.contain('Error: connect ECONNREFUSED 127.0.0.1:12345');
 
-          expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
+        expect(annotations[6].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
-          done();
-        });
+        expect(annotations[7]).to.be.undefined; // eslint-disable-line no-unused-expressions
+        done();
       });
     });
   });
 
   it('should report when service returns 400', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather/securedTown';
-        const url = `http://${apiHost}:${apiPort}${urlPath}`;
-        zipkinAxios({url, timeout: 100}).catch(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/securedTown';
+      const url = `http://${apiHost}:${apiPort}${urlPath}`;
+      zipkinAxiosClient({url, timeout: 100}).catch(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal(urlPath);
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('400');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('400');
 
-          expect(annotations[6].annotation.key).to.equal('error');
-          expect(annotations[6].annotation.value).to.equal('400');
+        expect(annotations[6].annotation.key).to.equal('error');
+        expect(annotations[6].annotation.value).to.equal('400');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+        expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
-          done();
-        });
+        expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+        done();
       });
     });
   });
 
   it('should report when service returns 500', done => {
     tracer.scoped(() => {
-      const apiServer = api.listen(0, () => {
-        const apiPort = apiServer.address().port;
-        const apiHost = '127.0.0.1';
-        const zipkinAxios = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
-        const urlPath = '/weather/bagCity';
-        const url = `http://${apiHost}:${apiPort}${urlPath}`;
-        zipkinAxios({url, timeout: 100}).catch(() => {
-          const annotations = record.args.map(args => args[0]);
-          const initialTraceId = annotations[0].traceId.traceId;
-          annotations.forEach(ann => expect(ann.traceId.traceId)
+      const zipkinAxiosClient = getClient();
+      const urlPath = '/weather/bagCity';
+      const url = `http://${apiHost}:${apiPort}${urlPath}`;
+      zipkinAxiosClient({url, timeout: 100}).catch(() => {
+        const annotations = record.args.map(args => args[0]);
+        const initialTraceId = annotations[0].traceId.traceId;
+        annotations.forEach(ann => expect(ann.traceId.traceId)
             .to.equal(initialTraceId).and
             .to.have.lengthOf(16));
 
-          expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
-          expect(annotations[1].annotation.annotationType).to.equal('Rpc');
-          expect(annotations[1].annotation.name).to.equal('GET');
+        expect(annotations[1].annotation.annotationType).to.equal('Rpc');
+        expect(annotations[1].annotation.name).to.equal('GET');
 
-          expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[2].annotation.key).to.equal('http.path');
-          expect(annotations[2].annotation.value).to.equal(urlPath);
+        expect(annotations[2].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[2].annotation.key).to.equal('http.path');
+        expect(annotations[2].annotation.value).to.equal(urlPath);
 
-          expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
+        expect(annotations[3].annotation.annotationType).to.equal('ClientSend');
 
-          expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
+        expect(annotations[4].annotation.annotationType).to.equal('ServerAddr');
 
-          expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
-          expect(annotations[5].annotation.key).to.equal('http.status_code');
-          expect(annotations[5].annotation.value).to.equal('500');
+        expect(annotations[5].annotation.annotationType).to.equal('BinaryAnnotation');
+        expect(annotations[5].annotation.key).to.equal('http.status_code');
+        expect(annotations[5].annotation.value).to.equal('500');
 
-          expect(annotations[6].annotation.key).to.equal('error');
-          expect(annotations[6].annotation.value).to.equal('500');
+        expect(annotations[6].annotation.key).to.equal('error');
+        expect(annotations[6].annotation.value).to.equal('500');
 
-          expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
+        expect(annotations[7].annotation.annotationType).to.equal('ClientRecv');
 
-          expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+        expect(annotations[8]).to.be.undefined; // eslint-disable-line no-unused-expressions
+        done();
+      });
+    });
+  });
+
+  it('should handle nested requests', done => {
+    tracer.scoped(() => {
+      const client = getClient();
+      const getBeijingWeather = client.get(`http://${apiHost}:${apiPort}/weather/beijing`);
+      const getWuhanWeather = client.get(`http://${apiHost}:${apiPort}/weather/wuhan`);
+
+      getBeijingWeather.then(() => {
+        getWuhanWeather.then(() => {
+          const annotations = record.args.map(args => args[0]);
+          let firstTraceId;
+          let beijingWeatherSpanId;
+          let beijingWeatherParentId;
+          let wuhanWeatherSpanId;
+          let wuhanWeatherParentId;
+
+          annotations.forEach(annot => {
+            if (firstTraceId) {
+              expect(annot.traceId.traceId === firstTraceId);
+            } else {
+              firstTraceId = annot.traceId.traceId;
+            }
+
+            if (annot.annotation.value === '/weather/beijing') {
+              beijingWeatherSpanId = annot.traceId.spanId;
+              beijingWeatherParentId = annot.traceId.parentId;
+            }
+            if (annot.annotation.value === '/weather/wuhan') {
+              wuhanWeatherSpanId = annot.traceId.spanId;
+              wuhanWeatherParentId = annot.traceId.parentId;
+            }
+
+            expect(annot.traceId.spanId).to.equal(annot.traceId.parentId);
+            expect(annot.traceId.parentId).to.equal(annot.traceId.spanId);
+          });
+
+          expect(beijingWeatherSpanId).to.not.equal(wuhanWeatherSpanId);
+          expect(beijingWeatherParentId).to.not.equal(wuhanWeatherParentId);
+          expect(beijingWeatherParentId).to.not.equal(wuhanWeatherSpanId);
+          expect(wuhanWeatherSpanId).to.not.equal(beijingWeatherSpanId);
+          expect(wuhanWeatherParentId).to.not.equal(beijingWeatherParentId);
+          expect(wuhanWeatherParentId).to.not.equal(beijingWeatherSpanId);
+
           done();
         });
       });
     });
+  });
+
+  it('should handle parallel requests', () => {
+    let promise;
+    tracer.scoped(() => {
+      const client = getClient();
+      const getBeijingWeather = client.get(`http://${apiHost}:${apiPort}/weather/beijing`);
+      const getWuhanWeather = client.get(`http://${apiHost}:${apiPort}/weather/wuhan`);
+      promise = Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
+        const annotations = record.args.map(args => args[0]);
+        let firstTraceId;
+        let beijingWeatherSpanId;
+        let beijingWeatherParentId;
+        let wuhanWeatherSpanId;
+        let wuhanWeatherParentId;
+
+        annotations.forEach(annot => {
+          if (firstTraceId) {
+            expect(annot.traceId.traceId === firstTraceId);
+          } else {
+            firstTraceId = annot.traceId.traceId;
+          }
+
+          if (annot.annotation.value === '/weather/beijing') {
+            beijingWeatherSpanId = annot.traceId.spanId;
+            beijingWeatherParentId = annot.traceId.parentId;
+          }
+          if (annot.annotation.value === '/weather/wuhan') {
+            wuhanWeatherSpanId = annot.traceId.spanId;
+            wuhanWeatherParentId = annot.traceId.parentId;
+          }
+
+          expect(annot.traceId.spanId).to.equal(annot.traceId.parentId);
+          expect(annot.traceId.parentId).to.equal(annot.traceId.spanId);
+        });
+
+        expect(beijingWeatherSpanId).to.not.equal(wuhanWeatherSpanId);
+        expect(beijingWeatherParentId).to.not.equal(wuhanWeatherParentId);
+        expect(beijingWeatherParentId).to.not.equal(wuhanWeatherSpanId);
+        expect(wuhanWeatherSpanId).to.not.equal(beijingWeatherSpanId);
+        expect(wuhanWeatherParentId).to.not.equal(beijingWeatherParentId);
+        expect(wuhanWeatherParentId).to.not.equal(beijingWeatherSpanId);
+      });
+    });
+    return promise;
   });
 });

--- a/packages/zipkin-instrumentation-axios/test/unitTest.js
+++ b/packages/zipkin-instrumentation-axios/test/unitTest.js
@@ -1,0 +1,29 @@
+import {Tracer, ExplicitContext} from 'zipkin';
+import axios from 'axios';
+import sinon from 'sinon';
+import {expect} from 'chai';
+import wrapAxios from '../src/index';
+
+describe('axios instrumentation - unit test', () => {
+  const serviceName = 'weather-app';
+  const remoteServiceName = 'weather-api';
+  let tracer;
+  beforeEach(() => {
+    const record = sinon.spy();
+    const recorder = {record};
+    const ctxImpl = new ExplicitContext();
+    tracer = new Tracer({recorder, ctxImpl});
+  });
+  it('should return an axios instance when pass axios', done => {
+    const axiosInstance = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
+    expect(axiosInstance.create).to.equal(undefined);
+    done();
+  });
+
+  it('should return itself when pass an axiosInstance', done => {
+    const axiosInstance = axios.create();
+    const zipkinAxiosInstance = wrapAxios(axiosInstance, {tracer, serviceName, remoteServiceName});
+    expect(axiosInstance).to.equal(zipkinAxiosInstance);
+    done();
+  });
+});

--- a/packages/zipkin-instrumentation-axios/test/utils.js
+++ b/packages/zipkin-instrumentation-axios/test/utils.js
@@ -1,0 +1,32 @@
+import express from 'express';
+
+export const mockServer = () => new Promise(resolve => {
+  const api = express();
+  api.get('/weather/wuhan', (req, res) => {
+    res.status(202).json({
+      traceId: req.header('X-B3-TraceId'),
+      spanId: req.header('X-B3-SpanId')
+    });
+  });
+  api.get('/weather/beijing', (req, res) => {
+    res.status(202).json({
+      traceId: req.header('X-B3-TraceId'),
+      spanId: req.header('X-B3-SpanId')
+    });
+  });
+  api.get('/weather/securedTown', (req, res) => {
+    res.status(400).json({
+      traceId: req.header('X-B3-TraceId'),
+      spanId: req.header('X-B3-SpanId')
+    });
+  });
+  api.get('/weather/bagCity', (req, res) => {
+    res.status(500).json({
+      traceId: req.header('X-B3-TraceId'),
+      spanId: req.header('X-B3-SpanId')
+    });
+  });
+  const apiServer = api.listen(0, () => {
+    resolve(apiServer);
+  });
+});


### PR DESCRIPTION
- pass traceId from request to response by config, traceId will change after record request
- avoid dirty `axios`, create an axios instance before using interceptors