### PR TITLE
Updating Timestamp in Console Recorder

### DIFF
--- a/packages/zipkin/src/console-recorder.js
+++ b/packages/zipkin/src/console-recorder.js
@@ -10,7 +10,7 @@ class ConsoleRecorder {
   record(rec) {
     const {spanId, parentId, traceId} = rec.traceId;
     this.logger(
-      `Record at (spanId=${spanId}, parentId=${parentId}, ` +
+      `Record at (timestamp=${rec.timestamp}, spanId=${spanId}, parentId=${parentId}, ` +
       `traceId=${traceId}): ${rec.annotation.toString()}`
     );
   }


### PR DESCRIPTION
Adding Timestamp to the Console Recorder Logger to record time across multiple requests.