### PR TITLE
Reflect supportsJoin agument parameter in types

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -34,6 +34,7 @@ declare namespace zipkin {
       ctxImpl: Context<TraceId>,
       recorder: Recorder,
       sampler?: sampler.Sampler,
+      supportsJoin?: boolean,
       traceId128Bit?: boolean,
       localServiceName?: string,
       localEndpoint?: model.Endpoint,


### PR DESCRIPTION
As far as I can see from [index.js](https://github.com/openzipkin/zipkin-js/blob/00604b73d938b25b36a754765cdcca435def1b07/packages/zipkin/src/tracer/index.js#L31), `supportsJoin` is a valid argument, so this PR reflects this in the typed arguments. 

Thank you for the awesome library!