### PR TITLE
Refactors TraceId type against known problems; fixes shared flag

### DIFF
--- a/packages/zipkin-encoder-thrift/test/index.test.js
+++ b/packages/zipkin-encoder-thrift/test/index.test.js
@@ -81,7 +81,7 @@ describe('Thrift v1 Formatting', () => {
     const span = new Span(new TraceId({
       traceId: '000000000000162e',
       spanId: '000000000000162e',
-      debug: 1
+      debug: true
     }));
 
     const expected = new thriftTypes.Span();

--- a/packages/zipkin-encoder-thrift/test/index.test.js
+++ b/packages/zipkin-encoder-thrift/test/index.test.js
@@ -8,7 +8,7 @@ const {
 const {
   TraceId,
   model: {Span, Endpoint},
-  option: {Some, None}
+  option: {Some}
 } = require('zipkin');
 
 function serialize(spanThrift) {
@@ -35,9 +35,7 @@ describe('Thrift v1 Formatting', () => {
   // v1 format requires an empty span name. v2 can leave it out
   it('should write minimum fields, notably an empty span name', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
-      spanId: '000000000000162e',
-      sampled: None
+      spanId: '000000000000162e'
     }));
 
     const expected = new thriftTypes.Span();
@@ -50,10 +48,9 @@ describe('Thrift v1 Formatting', () => {
 
   it('should write a parent ID when present', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
+      traceId: '000000000000162e',
       parentId: new Some('000000000000abcd'),
-      spanId: '000000000000efgh',
-      sampled: None
+      spanId: '000000000000efgh'
     }));
 
     const expected = new thriftTypes.Span();
@@ -67,7 +64,7 @@ describe('Thrift v1 Formatting', () => {
 
   it('should write trace ID high when input is a 128-bit trace ID', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('00000000000004d2000000000000162e'),
+      traceId: '00000000000004d2000000000000162e',
       spanId: '000000000000162e'
     }));
 
@@ -82,9 +79,9 @@ describe('Thrift v1 Formatting', () => {
 
   it('should write a debug flag', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
+      traceId: '000000000000162e',
       spanId: '000000000000162e',
-      flags: 1
+      debug: 1
     }));
 
     const expected = new thriftTypes.Span();
@@ -98,10 +95,9 @@ describe('Thrift v1 Formatting', () => {
 
   it('should transform correctly from Span to Thrift representation', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setLocalEndpoint(new Endpoint({
@@ -152,10 +148,9 @@ describe('Thrift v1 Formatting', () => {
 
   it('should not set timestamp or duration on shared span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('SERVER');
@@ -171,10 +166,9 @@ describe('Thrift v1 Formatting', () => {
 
   it('should set timestamp and duration on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('SERVER');
@@ -188,7 +182,6 @@ describe('Thrift v1 Formatting', () => {
 
   it('should set server address on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
       spanId: '000000000000162e'
     }));
     span.setName('GET');
@@ -222,7 +215,6 @@ describe('Thrift v1 Formatting', () => {
   // make sure nothing strange happens like object interpretation of dots
   it('should serialize tags with dotted names as binary annotations', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
       spanId: '000000000000162e'
     }));
     span.setName('GET');

--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -366,7 +366,7 @@ describe('axios instrumentation - integration test', () => {
               wuhanWeatherSpanId = annot.traceId.spanId;
             }
 
-            expect(annot.traceId.parentId).to.equal(None);
+            expect(annot.traceId.parentSpanId).to.equal(None);
           });
 
           expect(beijingWeatherSpanId).to.not.equal(wuhanWeatherSpanId);
@@ -403,7 +403,7 @@ describe('axios instrumentation - integration test', () => {
             wuhanWeatherSpanId = annot.traceId.spanId;
           }
 
-          expect(annot.traceId.parentId).to.equal(None);
+          expect(annot.traceId.parentSpanId).to.equal(None);
         });
 
         expect(beijingWeatherSpanId).to.not.equal(wuhanWeatherSpanId);

--- a/packages/zipkin-instrumentation-got/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-got/test/integrationTest.js
@@ -119,7 +119,7 @@ describe('wrapGot', () => {
           const {parentId, traceId} = firstArg._zipkin;
           expect(parentId).to.equal(id);
           expect(traceId).to.not.be.undefined; // eslint-disable-line no-unused-expressions
-          expect(traceId.parentId.getOrElse()).to.equal(id.traceId);
+          expect(traceId.parentSpanId.getOrElse()).to.equal(id.traceId);
           done();
         })
         .catch(done);

--- a/packages/zipkin-instrumentation-got/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-got/test/integrationTest.js
@@ -119,7 +119,7 @@ describe('wrapGot', () => {
           const {parentId, traceId} = firstArg._zipkin;
           expect(parentId).to.equal(id);
           expect(traceId).to.not.be.undefined; // eslint-disable-line no-unused-expressions
-          expect(traceId.parentId).to.equal(id.traceId);
+          expect(traceId.parentId.getOrElse()).to.equal(id.traceId);
           done();
         })
         .catch(done);

--- a/packages/zipkin-instrumentation-grpc-client/src/grpcClientInstrumentation.js
+++ b/packages/zipkin-instrumentation-grpc-client/src/grpcClientInstrumentation.js
@@ -61,7 +61,7 @@ class GrpcClientInstrumentation {
     metadata.add(HttpHeaders.TraceId, traceId.traceId);
     metadata.add(HttpHeaders.SpanId, traceId.spanId);
 
-    traceId._parentId.ifPresent(psid => {
+    traceId.parentSpanId.ifPresent(psid => {
       metadata.add(HttpHeaders.ParentSpanId, psid);
     });
     traceId.sampled.ifPresent(sampled => {

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -1,6 +1,6 @@
+const {option: {None}, Tracer} = require('zipkin');
 import uuid from 'uuid/v4';
 import CLSContext from 'zipkin-context-cls';
-import {Tracer} from 'zipkin';
 import sinon from 'sinon';
 import grpc from 'grpc';
 import grpcIntrumentation from '../src/grpcClientInterceptor';
@@ -110,9 +110,7 @@ describe('gRPC client instrumentation (integration test)', () => {
           const annotations = record.args.map(args => args[0]);
           let firstTraceId;
           let weatherSpanId;
-          let weatherParentId;
           let locationSpanId;
-          let locationParentId;
 
           annotations.forEach(annot => {
             if (firstTraceId) {
@@ -123,23 +121,15 @@ describe('gRPC client instrumentation (integration test)', () => {
 
             if (annot.annotation.name === '/weather.WeatherService/GetTemperature') {
               weatherSpanId = annot.traceId.spanId;
-              weatherParentId = annot.traceId.parentId;
             }
             if (annot.annotation.name === '/weather.WeatherService/GetLocations') {
               locationSpanId = annot.traceId.spanId;
-              locationParentId = annot.traceId.parentId;
             }
-
-            expect(annot.traceId.spanId).to.equal(annot.traceId.parentId);
-            expect(annot.traceId.parentId).to.equal(annot.traceId.spanId);
+            expect(annot.traceId.parentId).to.equal(None);
           });
 
           expect(weatherSpanId).to.not.equal(locationSpanId);
-          expect(weatherParentId).to.not.equal(locationParentId);
-          expect(weatherParentId).to.not.equal(locationSpanId);
           expect(locationSpanId).to.not.equal(weatherSpanId);
-          expect(locationParentId).to.not.equal(weatherParentId);
-          expect(locationParentId).to.not.equal(weatherSpanId);
 
           done();
         });
@@ -164,9 +154,7 @@ describe('gRPC client instrumentation (integration test)', () => {
         const annotations = record.args.map(args => args[0]);
         let firstTraceId;
         let weatherSpanId;
-        let weatherParentId;
         let locationSpanId;
-        let locationParentId;
 
         annotations.forEach(annot => {
           if (firstTraceId) {
@@ -177,23 +165,16 @@ describe('gRPC client instrumentation (integration test)', () => {
 
           if (annot.annotation.name === '/weather.WeatherService/GetTemperature') {
             weatherSpanId = annot.traceId.spanId;
-            weatherParentId = annot.traceId.parentId;
           }
           if (annot.annotation.name === '/weather.WeatherService/GetLocations') {
             locationSpanId = annot.traceId.spanId;
-            locationParentId = annot.traceId.parentId;
           }
 
-          expect(annot.traceId.spanId).to.equal(annot.traceId.parentId);
-          expect(annot.traceId.parentId).to.equal(annot.traceId.spanId);
+          expect(annot.traceId.parentId).to.equal(None);
         });
 
         expect(weatherSpanId).to.not.equal(locationSpanId);
-        expect(weatherParentId).to.not.equal(locationParentId);
-        expect(weatherParentId).to.not.equal(locationSpanId);
         expect(locationSpanId).to.not.equal(weatherSpanId);
-        expect(locationParentId).to.not.equal(weatherParentId);
-        expect(locationParentId).to.not.equal(weatherSpanId);
       });
     });
     return promise;

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -125,7 +125,7 @@ describe('gRPC client instrumentation (integration test)', () => {
             if (annot.annotation.name === '/weather.WeatherService/GetLocations') {
               locationSpanId = annot.traceId.spanId;
             }
-            expect(annot.traceId.parentId).to.equal(None);
+            expect(annot.traceId.parentSpanId).to.equal(None);
           });
 
           expect(weatherSpanId).to.not.equal(locationSpanId);
@@ -170,7 +170,7 @@ describe('gRPC client instrumentation (integration test)', () => {
             locationSpanId = annot.traceId.spanId;
           }
 
-          expect(annot.traceId.parentId).to.equal(None);
+          expect(annot.traceId.parentSpanId).to.equal(None);
         });
 
         expect(weatherSpanId).to.not.equal(locationSpanId);

--- a/packages/zipkin-instrumentation-memcached/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-memcached/test/integrationTest.js
@@ -105,7 +105,7 @@ describe('memcached interceptor', () => {
           ).not.to.equal(annotations[annotations.length / 2].traceId.spanId);
 
           annotations.forEach(ann => {
-            expect(ann.traceId.parentId).to.equal(firstAnn.traceId.traceId);
+            expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
             expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
             expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
           });

--- a/packages/zipkin-instrumentation-memcached/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-memcached/test/integrationTest.js
@@ -105,7 +105,7 @@ describe('memcached interceptor', () => {
           ).not.to.equal(annotations[annotations.length / 2].traceId.spanId);
 
           annotations.forEach(ann => {
-            expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
+            expect(ann.traceId.parentSpanId.getOrElse()).to.equal(firstAnn.traceId.traceId);
             expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
             expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
           });

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -66,7 +66,7 @@ describe('redis interceptor', () => {
         ).not.to.equal(annotations[annotations.length / 2].traceId.spanId);
 
         annotations.forEach(ann => {
-          expect(ann.traceId.parentId).to.equal(firstAnn.traceId.traceId);
+          expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
         });
@@ -110,7 +110,7 @@ describe('redis interceptor', () => {
         ).not.to.equal(annotations[Math.floor(annotations.length / 2)].traceId.spanId);
 
         annotations.forEach(ann => {
-          expect(ann.traceId.parentId).to.equal(firstAnn.traceId.traceId);
+          expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
         });
@@ -136,7 +136,7 @@ describe('redis interceptor', () => {
             const annotations = recorder.record.args.map(args => args[0]);
             const firstAnn = annotations[0];
             annotations.forEach(ann => {
-              expect(ann.traceId.parentId).to.equal(firstAnn.traceId.traceId);
+              expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
               expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
               expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
             });

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -66,7 +66,7 @@ describe('redis interceptor', () => {
         ).not.to.equal(annotations[annotations.length / 2].traceId.spanId);
 
         annotations.forEach(ann => {
-          expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
+          expect(ann.traceId.parentSpanId.getOrElse()).to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
         });
@@ -110,7 +110,7 @@ describe('redis interceptor', () => {
         ).not.to.equal(annotations[Math.floor(annotations.length / 2)].traceId.spanId);
 
         annotations.forEach(ann => {
-          expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
+          expect(ann.traceId.parentSpanId.getOrElse()).to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
           expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
         });
@@ -136,7 +136,7 @@ describe('redis interceptor', () => {
             const annotations = recorder.record.args.map(args => args[0]);
             const firstAnn = annotations[0];
             annotations.forEach(ann => {
-              expect(ann.traceId.parentId.getOrElse()).to.equal(firstAnn.traceId.traceId);
+              expect(ann.traceId.parentSpanId.getOrElse()).to.equal(firstAnn.traceId.traceId);
               expect(ann.traceId.traceId).to.equal(firstAnn.traceId.traceId);
               expect(ann.traceId.spanId).not.to.equal(firstAnn.traceId.traceId);
             });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -389,7 +389,7 @@ describe('request instrumentation - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId)
             .to.not.equal(rootId.traceId, 'the span id should not equal the root id'));
 
-          annotations.forEach(ann => expect(ann.traceId.parentId)
+          annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse())
             .to.have.lengthOf(16).and
             .to.equal(rootId.traceId, 'all spans should have the root as their parent'));
 
@@ -436,7 +436,7 @@ describe('request instrumentation - integration test', () => {
               .to.have.lengthOf(16).and
               .to.not.equal(rootId.traceId));
 
-            annotations.forEach(ann => expect(ann.traceId.parentId)
+            annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse())
               .to.have.lengthOf(16).and
               .to.equal(rootId.traceId, 'all spans should have the root as their parent'));
 

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -389,7 +389,7 @@ describe('request instrumentation - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId)
             .to.not.equal(rootId.traceId, 'the span id should not equal the root id'));
 
-          annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse())
+          annotations.forEach(ann => expect(ann.traceId.parentSpanId.getOrElse())
             .to.have.lengthOf(16).and
             .to.equal(rootId.traceId, 'all spans should have the root as their parent'));
 
@@ -436,7 +436,7 @@ describe('request instrumentation - integration test', () => {
               .to.have.lengthOf(16).and
               .to.not.equal(rootId.traceId));
 
-            annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse())
+            annotations.forEach(ann => expect(ann.traceId.parentSpanId.getOrElse())
               .to.have.lengthOf(16).and
               .to.equal(rootId.traceId, 'all spans should have the root as their parent'));
 

--- a/packages/zipkin-transport-scribe/test/integrationTest.js
+++ b/packages/zipkin-transport-scribe/test/integrationTest.js
@@ -47,11 +47,10 @@ describe('Scribe transport - integration test', () => {
       const tracer = new Tracer({recorder, ctxImpl});
       ctxImpl.scoped(() => {
         const id = new TraceId({
-          traceId: new Some('abc'),
+          traceId: 'abc',
           parentId: new Some('def'),
           spanId: '123',
-          sampled: new Some(true),
-          flags: 0
+          sampled: new Some(true)
         });
         tracer.setId(id);
         tracer.recordAnnotation(new Annotation.ServerAddr({serviceName: 'test'}));

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -62,19 +62,20 @@ declare namespace zipkin {
 
   class TraceId {
     readonly traceId: string;
-    readonly parentId: string;
+    readonly parentId: option.IOption<string>;
     readonly spanId: string;
     readonly sampled: option.IOption<boolean>;
-    readonly flags: number;
 
     isDebug(): boolean;
+    isShared(): boolean;
 
     constructor(args?: {
-      traceId?: option.IOption<string>,
+      traceId?: string,
       parentId?: option.IOption<string>,
       spanId?: string,
       sampled?: option.IOption<boolean>,
-      flags?: number
+      debug?: boolean,
+      shared?: boolean
     });
 
     toString(): string;

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -62,7 +62,7 @@ declare namespace zipkin {
 
   class TraceId {
     readonly traceId: string;
-    readonly parentId: option.IOption<string>;
+    readonly parentSpanId: option.IOption<string>;
     readonly spanId: string;
     readonly sampled: option.IOption<boolean>;
 

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -148,8 +148,7 @@ class BatchRecorder {
           span.delegate.setKind('SERVER');
           break;
         case 'ServerRecv':
-          // TODO: only set this to false when we know we in an existing trace
-          span.delegate.setShared(id.parentId !== id.spanId);
+          span.delegate.setShared(id.isShared());
           span.delegate.setKind('CLIENT');
           break;
         case 'ProducerStart':

--- a/packages/zipkin/src/instrumentation/httpServer.js
+++ b/packages/zipkin/src/instrumentation/httpServer.js
@@ -47,11 +47,11 @@ class HttpServerInstrumentation {
         const sampled = readHeader(Header.Sampled);
         const flags = readHeader(Header.Flags).flatMap(stringToIntOption).getOrElse(0);
         return new TraceId({
-          traceId,
+          traceId: traceId.getOrElse(),
           parentId: parentSpanId,
           spanId: sid,
+          debug: flags === 1,
           sampled: sampled.map(stringToBoolean),
-          flags
         });
       });
 

--- a/packages/zipkin/src/model.js
+++ b/packages/zipkin/src/model.js
@@ -28,7 +28,7 @@ Annotation.prototype.toString = function toString() {
 
 function Span(traceId) {
   this.traceId = traceId.traceId;
-  traceId._parentId.ifPresent((id) => {
+  traceId.parentSpanId.ifPresent((id) => {
     this.parentId = id;
   });
   this.id = traceId.spanId;

--- a/packages/zipkin/src/model.js
+++ b/packages/zipkin/src/model.js
@@ -41,7 +41,7 @@ function Span(traceId) {
   this.annotations = [];
   this.tags = {};
   this.debug = traceId.isDebug();
-  this.shared = false;
+  this.shared = traceId.isShared();
 }
 
 Span.prototype.setName = function setName(name) {

--- a/packages/zipkin/src/request.js
+++ b/packages/zipkin/src/request.js
@@ -5,7 +5,7 @@ function appendZipkinHeaders(req, traceId) {
   headers[HttpHeaders.TraceId] = traceId.traceId;
   headers[HttpHeaders.SpanId] = traceId.spanId;
 
-  traceId._parentId.ifPresent(psid => {
+  traceId.parentId.ifPresent(psid => {
     headers[HttpHeaders.ParentSpanId] = psid;
   });
   traceId.sampled.ifPresent(sampled => {

--- a/packages/zipkin/src/request.js
+++ b/packages/zipkin/src/request.js
@@ -5,7 +5,7 @@ function appendZipkinHeaders(req, traceId) {
   headers[HttpHeaders.TraceId] = traceId.traceId;
   headers[HttpHeaders.SpanId] = traceId.spanId;
 
-  traceId.parentId.ifPresent(psid => {
+  traceId.parentSpanId.ifPresent(psid => {
     headers[HttpHeaders.ParentSpanId] = psid;
   });
   traceId.sampled.ifPresent(sampled => {

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -1,44 +1,60 @@
-const {Some, None, verifyIsOptional, verifyIsNotOptional} = require('../option');
+const {
+  Some,
+  None,
+  verifyIsOptional,
+  verifyIsNotOptional
+} = require('../option');
+const T = new Some(true);
 
 class TraceId {
   constructor(params) {
-    const {traceId = None, parentId = None, spanId, sampled = None, flags = 0} = params;
-    verifyIsOptional(traceId);
-    verifyIsOptional(parentId);
+    const {
+      spanId,
+      traceId = spanId,
+      parentId = None,
+      flags = 0, // deprecated
+      debug = flags === 1,
+      sampled = None,
+      shared = false
+    } = params;
     verifyIsNotOptional(spanId);
+    verifyIsNotOptional(traceId);
+    verifyIsOptional(parentId);
     verifyIsOptional(sampled);
     this._traceId = traceId;
     this._parentId = parentId;
     this._spanId = spanId;
-    this._sampled = sampled;
-    this._flags = flags;
+    this._sampled = debug ? T : sampled;
+    this._debug = debug;
+    this._shared = shared;
+  }
+
+  get traceId() {
+    return this._traceId;
+  }
+
+  get parentId() {
+    return this._parentId;
   }
 
   get spanId() {
     return this._spanId;
   }
 
-  get parentId() {
-    return this._parentId.getOrElse(this.spanId);
-  }
-
-  get traceId() {
-    return this._traceId.getOrElse(this.parentId);
-  }
-
   get sampled() {
-    return this.isDebug() ? new Some(true) : this._sampled;
+    return this._sampled;
   }
 
   get flags() {
-    return this._flags;
+    return this._debug ? 1 : 0;
   }
 
   isDebug() {
-    // The jshint tool always complains about using bitwise operators,
-    // but in this case it's actually intentional, so we disable the warning:
-    // jshint bitwise: false
-    return (this._flags & 1) === 1;
+    return this._debug;
+  }
+
+  isShared() {
+    return this._shared;
   }
 
   toString() {

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -2,7 +2,8 @@ const {
   Some,
   None,
   verifyIsOptional,
-  verifyIsNotOptional
+  verifyIsNotOptional,
+  isOptional
 } = require('../option');
 const T = new Some(true);
 
@@ -18,10 +19,18 @@ class TraceId {
       shared = false
     } = params;
     verifyIsNotOptional(spanId);
-    verifyIsNotOptional(traceId);
     verifyIsOptional(parentId);
     verifyIsOptional(sampled);
-    this._traceId = traceId;
+
+    // support old signatures which allowed traceId to be optional
+    if (isOptional(traceId)) {
+      this._traceId = traceId.getOrElse(spanId);
+    } else if (typeof traceId === 'undefined' || traceId === null) {
+      this._traceId = spanId;
+    } else {
+      this._traceId = traceId;
+    }
+
     this._parentId = parentId;
     this._spanId = spanId;
     this._sampled = debug ? T : sampled;

--- a/packages/zipkin/src/tracer/TraceId.js
+++ b/packages/zipkin/src/tracer/TraceId.js
@@ -42,8 +42,17 @@ class TraceId {
     return this._traceId;
   }
 
-  get parentId() {
+  get parentSpanId() {
     return this._parentId;
+  }
+
+  /**
+   * Please use parentSpanId instead as this can return confusing results (the span ID when absent).
+   *
+   * @deprecated since version v0.19
+   */
+  get parentId() {
+    return this._parentId.getOrElse(this._spanId);
   }
 
   get spanId() {
@@ -54,6 +63,11 @@ class TraceId {
     return this._sampled;
   }
 
+  /**
+   * Please use isDebug instead.
+   *
+   * @deprecated since version v0.19
+   */
   get flags() {
     return this._debug ? 1 : 0;
   }
@@ -68,7 +82,7 @@ class TraceId {
 
   toString() {
     return `TraceId(spanId=${this.spanId.toString()}` +
-      `, parentId=${this.parentId.toString()}` +
+      `, parentSpanId=${this.parentSpanId.toString()}` +
       `, traceId=${this.traceId.toString()})`;
   }
 }

--- a/packages/zipkin/test-types/TraceId.test.ts
+++ b/packages/zipkin/test-types/TraceId.test.ts
@@ -15,7 +15,7 @@ describe('TraceId', () => {
     expect(sampled.map).to.be.a('function');
     expect(sampled).to.equal(option.None);
 
-    const parentId: option.IOption<string> = traceId.parentId;
+    const parentId: option.IOption<string> = traceId.parentSpanId;
     expect(parentId.map).to.be.a('function');
   });
 });

--- a/packages/zipkin/test-types/TraceId.test.ts
+++ b/packages/zipkin/test-types/TraceId.test.ts
@@ -4,12 +4,18 @@ import { option, TraceId } from 'zipkin';
 describe('TraceId', () => {
   it('should have correct type', () => {
     const traceId: TraceId = new TraceId({
-      traceId: new option.Some('48485a3953bb6124'),
-      spanId: '48485a3953bb6124'
+      traceId: '1',
+      parentId: new option.Some('1'),
+      spanId: '2'
     });
 
-    const sampled: option.IOption<boolean> = traceId.sampled;
+    expect(traceId.isShared()).to.equal(false);
 
+    const sampled: option.IOption<boolean> = traceId.sampled;
     expect(sampled.map).to.be.a('function');
+    expect(sampled).to.equal(option.None);
+
+    const parentId: option.IOption<string> = traceId.parentId;
+    expect(parentId.map).to.be.a('function');
   });
 });

--- a/packages/zipkin/test-types/jsonEncoder.test.ts
+++ b/packages/zipkin/test-types/jsonEncoder.test.ts
@@ -6,7 +6,7 @@ describe('JsonEncoder', () => {
         const v1: JsonEncoder = jsonEncoder.JSON_V1;
         const v2: JsonEncoder = jsonEncoder.JSON_V2;
 
-        const span: model.Span = new model.Span(new TraceId({ traceId: new option.Some('xyz')}));
+        const span: model.Span = new model.Span(new TraceId({ spanId: 'xyz' }));
 
         expect(v1.encode(span)).to.be.a('string');
         expect(v2.encode(span)).to.be.a('string');

--- a/packages/zipkin/test-types/model.test.ts
+++ b/packages/zipkin/test-types/model.test.ts
@@ -16,7 +16,7 @@ describe('Model', () => {
     describe('Span', () => {
         it('should have correct type', () => {
             const span: model.Span = new model.Span(new TraceId({
-                traceId: new option.Some('a'),
+                traceId: 'a',
                 spanId: 'b'
             }));
 

--- a/packages/zipkin/test-types/request.test.ts
+++ b/packages/zipkin/test-types/request.test.ts
@@ -6,7 +6,7 @@ describe('Request', () => {
     describe('addZipkinHeaders', () => {
         it('should have correct return types', () => {
             const traceId = new TraceId({
-                traceId: new Some('863ac35c9f6413ad48485a3953bb6124'),
+                traceId: '863ac35c9f6413ad48485a3953bb6124',
                 spanId: '48485a3953bb6124'
             });
 
@@ -21,7 +21,7 @@ describe('Request', () => {
 
         it('should have correct return types when using generic', () => {
             const traceId = new TraceId({
-                traceId: new Some('863ac35c9f6413ad48485a3953bb6124'),
+                traceId: '863ac35c9f6413ad48485a3953bb6124',
                 spanId: '48485a3953bb6124'
             });
 

--- a/packages/zipkin/test-types/request.test.ts
+++ b/packages/zipkin/test-types/request.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import {option, Request, RequestZipkinHeaders, TraceId} from 'zipkin';
-import Some = option.Some;
 
 describe('Request', () => {
     describe('addZipkinHeaders', () => {

--- a/packages/zipkin/test/TraceId.test.js
+++ b/packages/zipkin/test/TraceId.test.js
@@ -1,11 +1,40 @@
 const TraceId = require('../src/tracer/TraceId');
+const {Some, None} = require('../src/option');
 
 describe('TraceId', () => {
-  it('should accept a 64bit trace id', () => {
+  it('should accept old syntax where traceId can be left out', () => {
     const traceId = new TraceId({
       spanId: '48485a3953bb6124'
     });
     expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.spanId).to.equal('48485a3953bb6124');
+  });
+
+  it('should accept old syntax where traceId can be None', () => {
+    const traceId = new TraceId({
+      traceId: None,
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.spanId).to.equal('48485a3953bb6124');
+  });
+
+  it('should accept old syntax where traceId can be Some', () => {
+    const traceId = new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b'
+    });
+    expect(traceId.traceId).to.equal('a');
+    expect(traceId.spanId).to.equal('b');
+  });
+
+  it('should accept a 64bit trace id', () => {
+    const traceId = new TraceId({
+      traceId: '48485a3953bb6124',
+      spanId: '863ac35c9f6413ad'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.spanId).to.equal('863ac35c9f6413ad');
   });
 
   it('should accept a 128bit trace id', () => {

--- a/packages/zipkin/test/TraceId.test.js
+++ b/packages/zipkin/test/TraceId.test.js
@@ -1,10 +1,8 @@
-const {Some} = require('../src/option');
 const TraceId = require('../src/tracer/TraceId');
 
 describe('TraceId', () => {
   it('should accept a 64bit trace id', () => {
     const traceId = new TraceId({
-      traceId: new Some('48485a3953bb6124'),
       spanId: '48485a3953bb6124'
     });
     expect(traceId.traceId).to.equal('48485a3953bb6124');
@@ -12,7 +10,7 @@ describe('TraceId', () => {
 
   it('should accept a 128bit trace id', () => {
     const traceId = new TraceId({
-      traceId: new Some('863ac35c9f6413ad48485a3953bb6124'),
+      traceId: '863ac35c9f6413ad48485a3953bb6124',
       spanId: '48485a3953bb6124'
     });
     expect(traceId.traceId).to.equal('863ac35c9f6413ad48485a3953bb6124');

--- a/packages/zipkin/test/TraceId.test.js
+++ b/packages/zipkin/test/TraceId.test.js
@@ -2,32 +2,6 @@ const TraceId = require('../src/tracer/TraceId');
 const {Some, None} = require('../src/option');
 
 describe('TraceId', () => {
-  it('should accept old syntax where traceId can be left out', () => {
-    const traceId = new TraceId({
-      spanId: '48485a3953bb6124'
-    });
-    expect(traceId.traceId).to.equal('48485a3953bb6124');
-    expect(traceId.spanId).to.equal('48485a3953bb6124');
-  });
-
-  it('should accept old syntax where traceId can be None', () => {
-    const traceId = new TraceId({
-      traceId: None,
-      spanId: '48485a3953bb6124'
-    });
-    expect(traceId.traceId).to.equal('48485a3953bb6124');
-    expect(traceId.spanId).to.equal('48485a3953bb6124');
-  });
-
-  it('should accept old syntax where traceId can be Some', () => {
-    const traceId = new TraceId({
-      traceId: new Some('a'),
-      spanId: 'b'
-    });
-    expect(traceId.traceId).to.equal('a');
-    expect(traceId.spanId).to.equal('b');
-  });
-
   it('should accept a 64bit trace id', () => {
     const traceId = new TraceId({
       traceId: '48485a3953bb6124',
@@ -43,5 +17,91 @@ describe('TraceId', () => {
       spanId: '48485a3953bb6124'
     });
     expect(traceId.traceId).to.equal('863ac35c9f6413ad48485a3953bb6124');
+  });
+
+  it('parentSpanId should return None when absent', () => {
+    const traceId = new TraceId({
+      traceId: '863ac35c9f6413ad48485a3953bb6124',
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.parentSpanId).to.equal(None);
+  });
+
+  it('parentSpanId should return Some when present', () => {
+    const traceId = new TraceId({
+      traceId: 'a',
+      parentId: new Some('b'),
+      spanId: 'c'
+    });
+    expect(traceId.parentSpanId.getOrElse()).to.equal('b');
+  });
+
+  it('old syntax: traceId can be left out', () => {
+    const traceId = new TraceId({
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.spanId).to.equal('48485a3953bb6124');
+  });
+
+  it('old syntax: traceId can be None', () => {
+    const traceId = new TraceId({
+      traceId: None,
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.traceId).to.equal('48485a3953bb6124');
+    expect(traceId.spanId).to.equal('48485a3953bb6124');
+  });
+
+  it('old syntax: traceId can be Some', () => {
+    const traceId = new TraceId({
+      traceId: new Some('a'),
+      spanId: 'b'
+    });
+    expect(traceId.traceId).to.equal('a');
+    expect(traceId.spanId).to.equal('b');
+  });
+
+  it('old syntax: parentId should return spanId when absent', () => {
+    const traceId = new TraceId({
+      traceId: '863ac35c9f6413ad48485a3953bb6124',
+      spanId: '48485a3953bb6124'
+    });
+    expect(traceId.parentId).to.equal(traceId.spanId);
+  });
+
+  it('old syntax: parentId should return value when present', () => {
+    const traceId = new TraceId({
+      traceId: 'a',
+      parentId: new Some('b'),
+      spanId: 'c',
+    });
+    expect(traceId.parentId).to.equal('b');
+  });
+
+  it('old syntax: flags is 0 by default', () => {
+    const traceId = new TraceId({
+      traceId: 'a',
+      spanId: 'c',
+    });
+    expect(traceId.flags).to.equal(0);
+  });
+
+  it('old syntax: debug can be set from flags', () => {
+    const traceId = new TraceId({
+      traceId: 'a',
+      spanId: 'b',
+      flags: 1
+    });
+    expect(traceId.isDebug()).to.equal(true);
+  });
+
+  it('old syntax: flags is 1 when debug', () => {
+    const traceId = new TraceId({
+      traceId: 'a',
+      spanId: 'c',
+      debug: true
+    });
+    expect(traceId.flags).to.equal(1);
   });
 });

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -5,7 +5,7 @@ const BatchRecorder = require('../src/batch-recorder');
 const TraceId = require('../src/tracer/TraceId');
 const Annotation = require('../src/annotation');
 const InetAddress = require('../src/InetAddress');
-const {Some, None} = require('../src/option');
+const {Some} = require('../src/option');
 const ExplicitContext = require('../src/explicit-context');
 
 describe('Batch Recorder', () => {
@@ -19,7 +19,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
         sampled: new Some(true)
@@ -64,7 +64,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
         sampled: new Some(true)
@@ -85,8 +85,7 @@ describe('Batch Recorder', () => {
     });
   });
 
-  // TODO: handle this when headers are extracted instead of guessing
-  it('should set non-root server span as shared', () => {
+  it('should copy shared flag from trace id', () => {
     const logSpan = sinon.spy();
 
     const ctxImpl = new ExplicitContext();
@@ -96,10 +95,11 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
-        sampled: new Some(true)
+        sampled: new Some(true),
+        shared: true
       }));
 
       trace.recordServiceName('SmoothieStore');
@@ -124,7 +124,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: new Some('a'),
+        traceId: 'a',
         spanId: 'c',
         sampled: new Some(true)
       }));
@@ -158,7 +158,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: new Some('a'),
+        traceId: 'a',
         spanId: 'c',
         sampled: new Some(true)
       }));
@@ -185,7 +185,7 @@ describe('Batch Recorder', () => {
     const recorder = new BatchRecorder({logger});
     const trace = new Tracer({ctxImpl, recorder});
     const traceId = new TraceId({
-      traceId: None,
+      traceId: 'a',
       parentId: new Some('a'),
       spanId: 'c',
       sampled: new Some(true)
@@ -225,7 +225,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
         sampled: new Some(true)
@@ -257,7 +257,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
         sampled: new Some(true)
@@ -308,7 +308,7 @@ describe('Batch Recorder', () => {
 
     ctxImpl.scoped(() => {
       trace.setId(new TraceId({
-        traceId: None,
+        traceId: 'a',
         parentId: new Some('a'),
         spanId: 'c',
         sampled: new Some(true)

--- a/packages/zipkin/test/httpClientInstrumentation.test.js
+++ b/packages/zipkin/test/httpClientInstrumentation.test.js
@@ -33,6 +33,7 @@ describe('Http Client Instrumentation', () => {
     annotations.forEach(ann => expect(ann.traceId.traceId)
       .to.equal(initialTraceId).and
       .to.have.lengthOf(16));
+    annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
     expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
     expect(annotations[0].annotation.serviceName).to.equal('weather-app');

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -43,6 +43,7 @@ describe('Http Server Instrumentation', () => {
     annotations.forEach(ann => expect(ann.traceId.spanId)
       .to.have.lengthOf(16).and
       .to.equal(originalSpanId));
+    annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
     expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
     expect(annotations[0].annotation.serviceName).to.equal('service-a');
@@ -102,6 +103,7 @@ describe('Http Server Instrumentation', () => {
 
       annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
       annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
+      annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(true));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
       expect(annotations[0].annotation.serviceName).to.equal('service-a');
@@ -152,8 +154,9 @@ describe('Http Server Instrumentation', () => {
       const annotations = record.args.map(args => args[0]);
 
       annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
-      annotations.forEach(ann => expect(ann.traceId.parentId).to.equal('bbb'));
+      annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse()).to.equal('bbb'));
       annotations.forEach(ann => expect(ann.traceId.spanId).to.not.equal('bbb'));
+      annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
       expect(annotations[0].annotation.serviceName).to.equal('service-a');
@@ -232,6 +235,7 @@ describe('Http Server Instrumentation', () => {
       if (hasAnnotations === true) {
         annotations.forEach(ann => expect(ann.traceId.traceId).to.not.be.empty);
         annotations.forEach(ann => expect(ann.traceId.spanId).to.not.be.empty);
+        annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
         expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
         expect(annotations[0].annotation.serviceName).to.equal('service-a');

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -154,7 +154,7 @@ describe('Http Server Instrumentation', () => {
       const annotations = record.args.map(args => args[0]);
 
       annotations.forEach(ann => expect(ann.traceId.traceId).to.equal('aaa'));
-      annotations.forEach(ann => expect(ann.traceId.parentId.getOrElse()).to.equal('bbb'));
+      annotations.forEach(ann => expect(ann.traceId.parentSpanId.getOrElse()).to.equal('bbb'));
       annotations.forEach(ann => expect(ann.traceId.spanId).to.not.equal('bbb'));
       annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 

--- a/packages/zipkin/test/jsonEncoder.JSON_V1.test.js
+++ b/packages/zipkin/test/jsonEncoder.JSON_V1.test.js
@@ -1,15 +1,13 @@
 const TraceId = require('../src/tracer/TraceId');
 const {Span, Endpoint} = require('../src/model');
 const {JSON_V1} = require('../src/jsonEncoder');
-const {Some, None} = require('../src/option');
+const {Some} = require('../src/option');
 
 describe('JSON v1 Formatting', () => {
   // v1 format requires an empty span name. v2 can leave it out
   it('should write minimum fields, notably an empty span name', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
-      spanId: '000000000000162e',
-      sampled: None
+      spanId: '000000000000162e'
     }));
 
     expect(JSON_V1.encode(span)).to.equal(
@@ -19,10 +17,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should write a parent ID when present', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
+      traceId: '000000000000162e',
       parentId: new Some('000000000000abcd'),
-      spanId: '000000000000efgh',
-      sampled: None
+      spanId: '000000000000efgh'
     }));
 
     expect(JSON_V1.encode(span)).to.contain(
@@ -32,7 +29,7 @@ describe('JSON v1 Formatting', () => {
 
   it('should write a 128-bit trace ID', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('00000000000004d2000000000000162e'),
+      traceId: '00000000000004d2000000000000162e',
       spanId: '000000000000162e'
     }));
 
@@ -43,9 +40,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should write a debug flag', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('00000000000004d2000000000000162e'),
+      traceId: '00000000000004d2000000000000162e',
       spanId: '000000000000162e',
-      flags: 1
+      debug: true
     }));
 
     expect(JSON_V1.encode(span)).to.contain(',"debug":true}');
@@ -53,10 +50,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should transform correctly from Span to JSON representation', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setLocalEndpoint(new Endpoint({
@@ -119,10 +115,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should not set timestamp or duration on shared span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('SERVER');
@@ -138,10 +133,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should set timestamp and duration on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('CLIENT');
@@ -153,10 +147,9 @@ describe('JSON v1 Formatting', () => {
 
   it('should set server address on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('CLIENT');
@@ -175,10 +168,9 @@ describe('JSON v1 Formatting', () => {
   // make sure nothing strange happens like object interpretation of dots
   it('should serialize tags with dotted names as binary annotations', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.putTag('http.path', '/api');

--- a/packages/zipkin/test/jsonEncoder.JSON_V2.test.js
+++ b/packages/zipkin/test/jsonEncoder.JSON_V2.test.js
@@ -1,14 +1,12 @@
 const TraceId = require('../src/tracer/TraceId');
 const {Span, Endpoint} = require('../src/model');
 const {JSON_V2} = require('../src/jsonEncoder');
-const {Some, None} = require('../src/option');
+const {Some} = require('../src/option');
 
 describe('JSON v2 Formatting', () => {
   it('should write minimum fields', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
-      spanId: '000000000000162e',
-      sampled: None
+      spanId: '000000000000162e'
     }));
 
     expect(JSON_V2.encode(span)).to.equal(
@@ -18,10 +16,9 @@ describe('JSON v2 Formatting', () => {
 
   it('should write a parent ID when present', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('000000000000162e'),
+      traceId: '000000000000162e',
       parentId: new Some('000000000000abcd'),
-      spanId: '000000000000efgh',
-      sampled: None
+      spanId: '000000000000efgh'
     }));
 
     expect(JSON_V2.encode(span)).to.contain(
@@ -31,7 +28,7 @@ describe('JSON v2 Formatting', () => {
 
   it('should write a 128-bit trace ID', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('00000000000004d2000000000000162e'),
+      traceId: '00000000000004d2000000000000162e',
       spanId: '000000000000162e'
     }));
 
@@ -42,9 +39,9 @@ describe('JSON v2 Formatting', () => {
 
   it('should write a debug flag', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('00000000000004d2000000000000162e'),
+      traceId: '00000000000004d2000000000000162e',
       spanId: '000000000000162e',
-      flags: 1
+      debug: true
     }));
 
     expect(JSON_V2.encode(span)).to.contain(',"debug":true}');
@@ -52,10 +49,9 @@ describe('JSON v2 Formatting', () => {
 
   it('should transform correctly from Span to JSON representation', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setLocalEndpoint(new Endpoint({
@@ -97,12 +93,11 @@ describe('JSON v2 Formatting', () => {
 
   it('should set shared', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
       spanId: 'c',
-      sampled: None
+      shared: true
     }));
-    span.setShared(true);
 
     const spanJson = JSON_V2.encode(span);
 
@@ -111,10 +106,9 @@ describe('JSON v2 Formatting', () => {
 
   it('should set timestamp and duration on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('CLIENT');
@@ -126,10 +120,9 @@ describe('JSON v2 Formatting', () => {
 
   it('should set remoteEndpoint on client span', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.setKind('CLIENT');
@@ -148,10 +141,9 @@ describe('JSON v2 Formatting', () => {
   // make sure nothing strange happens like object interpretation of dots
   it('should serialize tags with dotted names', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       parentId: new Some('b'),
-      spanId: 'c',
-      sampled: None
+      spanId: 'c'
     }));
     span.setName('GET');
     span.putTag('http.path', '/api');

--- a/packages/zipkin/test/model.test.js
+++ b/packages/zipkin/test/model.test.js
@@ -1,6 +1,5 @@
 const TraceId = require('../src/tracer/TraceId');
 const {Span, Endpoint} = require('../src/model');
-const {Some} = require('../src/option');
 
 describe('Endpoint setters', () => {
   // Zipkin does this, so doing so early alerts users
@@ -16,7 +15,7 @@ describe('Span setters', () => {
   // Zipkin does this, so doing so early alerts users
   it('should lowercase name', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       spanId: 'b',
     }));
     span.setName('StarWars');
@@ -26,7 +25,7 @@ describe('Span setters', () => {
   // otherwise people can't find their spans
   it('span.setLocalEndpoint() should accept unknown serviceName', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       spanId: 'b',
     }));
     span.setLocalEndpoint(new Endpoint({
@@ -37,7 +36,7 @@ describe('Span setters', () => {
 
   it('should not set empty endpoints', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       spanId: 'b',
     }));
     span.setLocalEndpoint(new Endpoint({}));
@@ -49,7 +48,7 @@ describe('Span setters', () => {
 
   it('should set minimum duration of 1 microsecond', () => {
     const span = new Span(new TraceId({
-      traceId: new Some('a'),
+      traceId: 'a',
       spanId: 'b',
     }));
     span.setDuration(0.77);
@@ -62,7 +61,7 @@ describe('Span setters', () => {
   annotationTypesCases.forEach(([annotationValue, expectedValue]) => {
     it(`should convert ${typeof annotationValue} annotation values to strings`, () => {
       const span = new Span(new TraceId({
-        traceId: new Some('a'),
+        traceId: 'a',
         spanId: 'b',
       }));
       span.addAnnotation(101239, annotationValue);
@@ -78,7 +77,7 @@ describe('Span setters', () => {
   tagTypesCases.forEach(([tagValue, expectedValue]) => {
     it(`should convert ${typeof tagValue} tag values to strings`, () => {
       const span = new Span(new TraceId({
-        traceId: new Some('a'),
+        traceId: 'a',
         spanId: 'b',
       }));
       span.putTag('c', tagValue);

--- a/packages/zipkin/test/request.test.js
+++ b/packages/zipkin/test/request.test.js
@@ -6,7 +6,6 @@ const TraceId = require('../src/tracer/TraceId');
 describe('Request', () => {
   it('should add trace/span and ignore parent span/sampled headers if they do not exist', () => {
     const traceId = new TraceId({
-      traceId: new Some('48485a3953bb6124'),
       spanId: '48485a3953bb6124'
     });
     const req = Request.addZipkinHeaders({}, traceId);
@@ -17,10 +16,10 @@ describe('Request', () => {
 
   it('should add trace, span, parent span, and sampled headers', () => {
     const traceId = new TraceId({
-      traceId: new Some('48485a3953bb6124'),
+      traceId: '48485a3953bb6124',
       spanId: '48485a3953bb6124',
       parentId: new Some('d56852c923dc9325'),
-      sampled: new Some('3598a2cc24dc8315')
+      sampled: new Some(true)
     });
     const req = Request.addZipkinHeaders({}, traceId);
 

--- a/packages/zipkin/test/sampler.test.js
+++ b/packages/zipkin/test/sampler.test.js
@@ -5,13 +5,13 @@ const {Some, None} = require('../src/option');
 const T = new Some(true);
 const F = new Some(false);
 
-function makeTestTraceId({flags = 0, sampled = None}) {
+function makeTestTraceId({debug = false, sampled = None}) {
   return new TraceId({
-    traceId: new Some('abc'),
+    traceId: 'abc',
     parentId: new Some('123'),
     spanId: 'fab',
     sampled,
-    flags
+    debug
   });
 }
 
@@ -20,7 +20,7 @@ describe('Sampler', () => {
     const neverSample = () => false;
     const sampler = new Sampler(neverSample);
     expect(
-      sampler.shouldSample(makeTestTraceId({flags: 1}))
+      sampler.shouldSample(makeTestTraceId({debug: true}))
     ).to.eql(T);
   });
   it('should respect the "sampled" property when true', () => {

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -32,14 +32,14 @@ describe('Tracer', () => {
         tracer.setId(childId);
 
         expect(tracer.id.traceId).to.equal(parentId.traceId);
-        expect(tracer.id.parentId).to.equal(parentId.spanId);
+        expect(tracer.id.parentId.getOrElse()).to.equal(parentId.spanId);
 
         ctxImpl.scoped(() => {
           const grandChildId = tracer.createChildId();
           tracer.setId(grandChildId);
 
           expect(tracer.id.traceId).to.equal(childId.traceId);
-          expect(tracer.id.parentId).to.equal(childId.spanId);
+          expect(tracer.id.parentId.getOrElse()).to.equal(childId.spanId);
         });
       });
     });
@@ -401,7 +401,7 @@ describe('Tracer', () => {
 
     const newTraceId = tracer.join(rootTraceId);
     expect(newTraceId.traceId).to.eql(rootTraceId.traceId);
-    expect(newTraceId.parentId).to.eql(rootTraceId.spanId);
+    expect(newTraceId.parentId).to.eql(new Some(rootTraceId.spanId));
     expect(newTraceId.sampled).to.eql(rootTraceId.sampled);
     expect(newTraceId.flags).to.eql(rootTraceId.flags);
   });

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -32,14 +32,14 @@ describe('Tracer', () => {
         tracer.setId(childId);
 
         expect(tracer.id.traceId).to.equal(parentId.traceId);
-        expect(tracer.id.parentId.getOrElse()).to.equal(parentId.spanId);
+        expect(tracer.id.parentSpanId.getOrElse()).to.equal(parentId.spanId);
 
         ctxImpl.scoped(() => {
           const grandChildId = tracer.createChildId();
           tracer.setId(grandChildId);
 
           expect(tracer.id.traceId).to.equal(childId.traceId);
-          expect(tracer.id.parentId.getOrElse()).to.equal(childId.spanId);
+          expect(tracer.id.parentSpanId.getOrElse()).to.equal(childId.spanId);
         });
       });
     });
@@ -401,7 +401,7 @@ describe('Tracer', () => {
 
     const newTraceId = tracer.join(rootTraceId);
     expect(newTraceId.traceId).to.eql(rootTraceId.traceId);
-    expect(newTraceId.parentId).to.eql(new Some(rootTraceId.spanId));
+    expect(newTraceId.parentSpanId).to.eql(new Some(rootTraceId.spanId));
     expect(newTraceId.sampled).to.eql(rootTraceId.sampled);
     expect(newTraceId.flags).to.eql(rootTraceId.flags);
   });


### PR DESCRIPTION
Before, the shared flag wasn't implemented correctly, which could lead
to data problems. Moreover, `TraceId.parentId` returned a heuristic
of the same as `TraceId.spanId` when absent: this causes data problems
and is an known antipattern. Finally, 'flags', an implementation detail
of the old B3 header was exposed instead of 'debug'

This fixes all of these problems. Another commit will make the change
compatible with existing implementations via deprecations:

* `TraceId.parentId` -> `TraceId.parentSpanId` with option result
* `TraceId.flags` -> `TraceId.isDebug()` -- already present
* Bad `TraceId` ctor parameter which allowed `traceId` to be absent: conditional detection, favoring plain str
ing.