### PR TITLE
Shows object diff when an async assertion fails

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -3,6 +3,12 @@ const chai = require('chai');
 chai.config.includeStack = true;
 global.expect = chai.expect;
 
+// Otherwise assertion failures in async tests are wrapped, which prevents mocha from
+// being able to interpret them (such as displaying a diff).
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
 if (process.env.TEST_SUITE === 'browser') {
   /* eslint-disable no-console */
   console.log('WARN: Skipping nodejs tests because TEST_SUITE is \'browser\'.');


### PR DESCRIPTION
Before, the assertion failure that mocha could readily interpret was
wrapped when inside an async hook. This made for very not helpful
failures.

This unwraps to prevent this.

before:
```
(node:70680) UnhandledPromiseRejectionWarning: AssertionError: expected { Object (http.path, http.status_code) } to deeply equal { Object (http.path, http.status_code) }
```

after:

```
  1) axios instrumentation - integration test
       should support request shorthand (defaults to GET):

      Uncaught AssertionError: expected { Object (http.path, http.status_code) } to deeply equal { Object (http.path, http.status_code) }
      + expected - actual

       {
         "http.path": "/weather/wuhan"
      -  "http.status_code": "202"
      +  "http.status_code": "2022"
       }
```

See https://github.com/mochajs/mocha/issues/2797