### PR TITLE
Refactors client integration tests slightly and backfills cujojs-rest

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -49,7 +49,7 @@ describe('axios instrumentation - integration test', () => {
 
   function getClient() {
     const instance = axios.create({
-      timeout: 200 // this avoids flakes in CI
+      timeout: 300 // this avoids flakes in CI
     });
 
     return wrapAxios(instance, {tracer, serviceName, remoteServiceName});

--- a/packages/zipkin-instrumentation-cujojs-rest/package.json
+++ b/packages/zipkin-instrumentation-cujojs-rest/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --exit --require ../../test/helper.js",
+    "test": "mocha --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
+    "test-browser": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "prepublish": "npm run build"
   },
   "author": "OpenZipkin <openzipkin.alt@gmail.com>",

--- a/test/testFixture.js
+++ b/test/testFixture.js
@@ -21,4 +21,29 @@ function newSpanRecorder(spans) {
   }}});
 }
 
-module.exports = {maybeMiddleware, newSpanRecorder}
+function expectB3Headers(span, requestHeaders) {
+  expect(requestHeaders['x-b3-traceid']).to.equal(span.traceId);
+  expect(requestHeaders['x-b3-spanid']).to.equal(span.id);
+  expect(requestHeaders['x-b3-sampled']).to.equal('1');
+
+  /* eslint-disable no-unused-expressions */
+  expect(requestHeaders['x-b3-parentspanid']).to.not.exist;
+  expect(requestHeaders['x-b3-flags']).to.not.exist;
+}
+
+function expectSpan(span, expected) {
+  expect(span.traceId)
+    .to.equal(span.id).and
+    .to.have.lengthOf(16);
+
+  const volatileProperties = {
+    traceId: span.traceId,
+    id: span.id,
+    timestamp: span.timestamp,
+    duration: span.duration
+  }
+
+  expect(span).to.deep.equal({...volatileProperties, ...expected});
+}
+
+module.exports = {maybeMiddleware, newSpanRecorder, expectB3Headers, expectSpan}


### PR DESCRIPTION
This refactors tests so that spans look more like literals. It also
pulls up some common logic. Finally, this backfills tests that pass
on cujojs-rest