### PR TITLE
fix: checks if there is a start timestamp to properly detect timeout.

### DIFF
--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -96,7 +96,7 @@ class BatchRecorder {
 
     // TODO(adriancole) refactor so this responsibility isn't in writeSpan
     if (span === undefined) {
-      // Span not found.  Could have been expired.
+      // Span not found. Could have been expired.
       return;
     }
 
@@ -128,6 +128,10 @@ class BatchRecorder {
   }
 
   _timedOut(span) {
+    if (span.startTimestamp === undefined) {
+      return false;
+    }
+
     return span.startTimestamp + this.timeout < now();
   }
 


### PR DESCRIPTION
If a span has no startTimestamp timeout checks should not apply.

Problem with spans with no timestamp is that the UI can't render it.

Ping @adriancole 