### PR TITLE
Fixes various timestamp problems, notably when a span is flushed

### DIFF
--- a/packages/zipkin/test/batch-recorder.integrationTest.js
+++ b/packages/zipkin/test/batch-recorder.integrationTest.js
@@ -1,5 +1,4 @@
 const {expect} = require('chai');
-const {expectSpan} = require('../../../test/testFixture');
 
 const Annotation = require('../src/annotation');
 const BatchRecorder = require('../src/batch-recorder');
@@ -20,6 +19,10 @@ describe('Batch Recorder - integration test', () => {
     }}});
   });
 
+  function pendingSpan(traceId) {
+    return recorder.partialSpans.get(traceId);
+  }
+
   function popSpan() {
     expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
     return spans.pop();
@@ -38,79 +41,103 @@ describe('Batch Recorder - integration test', () => {
     sampled: new Some(true)
   });
 
-  function newRecord(traceId, annotation) {
-    return new Record({traceId, annotation});
+  function record(traceId, timestamp, annotation) {
+    return new Record({traceId, timestamp, annotation});
   }
 
   it('should start and finish a client span', () => {
-    recorder.record(newRecord(rootId, new Annotation.ClientSend()));
-    recorder.record(newRecord(rootId, new Annotation.ClientRecv()));
+    recorder.record(record(rootId, 1, new Annotation.ClientSend()));
+    recorder.record(record(rootId, 3, new Annotation.ClientRecv()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       kind: 'CLIENT',
+      timestamp: 1,
+      duration: 2
     });
 
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
   it('should start and finish a server span', () => {
-    recorder.record(newRecord(rootId, new Annotation.ServerRecv()));
-    recorder.record(newRecord(rootId, new Annotation.ServerSend()));
+    recorder.record(record(rootId, 1, new Annotation.ServerRecv()));
+    recorder.record(record(rootId, 3, new Annotation.ServerSend()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       kind: 'SERVER',
+      timestamp: 1,
+      duration: 2
     });
 
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
   it('should start and finish a producer span', () => {
-    recorder.record(newRecord(rootId, new Annotation.ProducerStart()));
-    recorder.record(newRecord(rootId, new Annotation.ProducerStop()));
+    recorder.record(record(rootId, 1, new Annotation.ProducerStart()));
+    recorder.record(record(rootId, 3, new Annotation.ProducerStop()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       kind: 'PRODUCER',
+      timestamp: 1,
+      duration: 2
     });
 
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
   it('should start and finish a consumer span', () => {
-    recorder.record(newRecord(rootId, new Annotation.ConsumerStart()));
-    recorder.record(newRecord(rootId, new Annotation.ConsumerStop()));
+    recorder.record(record(rootId, 1, new Annotation.ConsumerStart()));
+    recorder.record(record(rootId, 3, new Annotation.ConsumerStop()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       kind: 'CONSUMER',
+      timestamp: 1,
+      duration: 2
     });
 
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
   it('should start and finish a local span', () => {
-    recorder.record(newRecord(rootId, new Annotation.LocalOperationStart('foo')));
-    recorder.record(newRecord(rootId, new Annotation.LocalOperationStop()));
+    recorder.record(record(rootId, 1, new Annotation.LocalOperationStart('foo')));
+    recorder.record(record(rootId, 3, new Annotation.LocalOperationStop()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       name: 'foo',
+      timestamp: 1,
+      duration: 2
     });
 
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
   it('should accommodate late changes to span name', () => {
-    recorder.record(newRecord(rootId, new Annotation.ServiceName('backend')));
-    recorder.record(newRecord(rootId, new Annotation.Rpc('GET')));
-    recorder.record(newRecord(rootId, new Annotation.BinaryAnnotation('http.path', '/api')));
-    recorder.record(newRecord(rootId, new Annotation.ServerRecv()));
+    recorder.record(record(rootId, 1, new Annotation.ServiceName('backend')));
+    recorder.record(record(rootId, 1, new Annotation.Rpc('GET')));
+    recorder.record(record(rootId, 1, new Annotation.BinaryAnnotation('http.path', '/api')));
+    recorder.record(record(rootId, 1, new Annotation.ServerRecv()));
 
     // when the response is ready to send, we have a name change
-    recorder.record(newRecord(rootId, new Annotation.Rpc('GET /api')));
-    recorder.record(newRecord(rootId, new Annotation.BinaryAnnotation('http.status_code', '200')));
-    recorder.record(newRecord(rootId, new Annotation.ServerSend()));
+    recorder.record(record(rootId, 3, new Annotation.Rpc('GET /api')));
+    recorder.record(record(rootId, 3, new Annotation.BinaryAnnotation('http.status_code', '200')));
+    recorder.record(record(rootId, 3, new Annotation.ServerSend()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       name: 'get /api',
       kind: 'SERVER',
+      timestamp: 1,
+      duration: 2,
       localEndpoint: {
         serviceName: 'backend'
       },
@@ -124,25 +151,29 @@ describe('Batch Recorder - integration test', () => {
   });
 
   it('should handle overlapping server and client', () => {
-    recorder.record(newRecord(rootId, new Annotation.ServiceName('frontend')));
-    recorder.record(newRecord(rootId, new Annotation.Rpc('GET')));
-    recorder.record(newRecord(rootId, new Annotation.BinaryAnnotation('http.path', '/')));
-    recorder.record(newRecord(rootId, new Annotation.ServerRecv()));
+    recorder.record(record(rootId, 1, new Annotation.ServiceName('frontend')));
+    recorder.record(record(rootId, 1, new Annotation.Rpc('GET')));
+    recorder.record(record(rootId, 1, new Annotation.BinaryAnnotation('http.path', '/')));
+    recorder.record(record(rootId, 1, new Annotation.ServerRecv()));
 
-    recorder.record(newRecord(childId, new Annotation.ServiceName('frontend')));
-    recorder.record(newRecord(childId, new Annotation.Rpc('GET')));
-    recorder.record(newRecord(childId, new Annotation.BinaryAnnotation('http.path', '/api')));
-    recorder.record(newRecord(childId, new Annotation.ClientSend()));
-    recorder.record(newRecord(childId, new Annotation.BinaryAnnotation('error', 'ECONNREFUSED')));
-    recorder.record(newRecord(childId, new Annotation.ClientRecv()));
+    recorder.record(record(childId, 3, new Annotation.ServiceName('frontend')));
+    recorder.record(record(childId, 3, new Annotation.Rpc('GET')));
+    recorder.record(record(childId, 3, new Annotation.BinaryAnnotation('http.path', '/api')));
+    recorder.record(record(childId, 3, new Annotation.ClientSend()));
+    recorder.record(record(childId, 4, new Annotation.BinaryAnnotation('error', 'ECONNREFUSED')));
+    recorder.record(record(childId, 4, new Annotation.ClientRecv()));
 
-    recorder.record(newRecord(rootId, new Annotation.BinaryAnnotation('http.status_code', '500')));
-    recorder.record(newRecord(rootId, new Annotation.BinaryAnnotation('error', 'client fail')));
-    recorder.record(newRecord(rootId, new Annotation.ServerSend()));
+    recorder.record(record(rootId, 6, new Annotation.BinaryAnnotation('http.status_code', '500')));
+    recorder.record(record(rootId, 6, new Annotation.BinaryAnnotation('error', 'client fail')));
+    recorder.record(record(rootId, 6, new Annotation.ServerSend()));
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
       name: 'get',
       kind: 'SERVER',
+      timestamp: 1,
+      duration: 5,
       localEndpoint: {
         serviceName: 'frontend'
       },
@@ -153,16 +184,97 @@ describe('Batch Recorder - integration test', () => {
       }
     });
 
-    expectSpan(popSpan(), {
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
       parentId: rootId.spanId,
+      id: childId.spanId,
       name: 'get',
       kind: 'CLIENT',
+      timestamp: 3,
+      duration: 1,
       localEndpoint: {
         serviceName: 'frontend'
       },
       tags: {
         error: 'ECONNREFUSED',
         'http.path': '/api'
+      }
+    });
+
+    expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should keep state until finished', () => {
+    recorder.record(record(rootId, 1, new Annotation.ClientSend()));
+    expect(pendingSpan(rootId)).to.exist; // eslint-disable-line no-unused-expressions
+
+    recorder.record(record(rootId, 3, new Annotation.ClientRecv()));
+    expect(pendingSpan(rootId)).to.not.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  /**
+   * Due to the code structure of httpClient.js, we can't externally propagate the start timestamp
+   * for the purpose of ensuring duration gets recorded even when flushed.
+   *
+   * This shows that once we refactor or replace this type, we will be able to restore duration by
+   * replaying the start event, and without causing confusion when there is not flush.
+   */
+  it('should allow redundant reporting of start timestamp', () => {
+    recorder.record(record(rootId, 1, new Annotation.ClientSend()));
+
+    // pretend an async callback redundantly replays the send event
+    recorder.record(record(rootId, 1, new Annotation.ClientSend()));
+    recorder.record(record(rootId, 3, new Annotation.ClientRecv()));
+
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
+      kind: 'CLIENT',
+      timestamp: 1,
+      duration: 2
+    });
+
+    expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should report sane data even on timeout', () => {
+    recorder.setDefaultTags({environment: 'production'});
+
+    recorder.record(record(rootId, 1, new Annotation.ServiceName('frontend')));
+    recorder.record(record(rootId, 1, new Annotation.Rpc('GET')));
+    recorder.record(record(rootId, 1, new Annotation.BinaryAnnotation('http.path', '/api')));
+    recorder.record(record(rootId, 1, new Annotation.ClientSend()));
+    recorder._writeSpan(rootId, pendingSpan(rootId)); // simulate timeout
+    expect(pendingSpan(rootId)).to.not.exist; // eslint-disable-line no-unused-expressions
+
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
+      kind: 'CLIENT',
+      timestamp: 1,
+      name: 'get',
+      localEndpoint: {
+        serviceName: 'frontend'
+      },
+      tags: {
+        environment: 'production',
+        'http.path': '/api'
+      }
+    });
+
+    recorder.record(record(rootId, 3, new Annotation.BinaryAnnotation('error', 'timeout')));
+    recorder.record(record(rootId, 3, new Annotation.ClientRecv()));
+    expect(pendingSpan(rootId)).to.not.exist; // eslint-disable-line no-unused-expressions
+
+    expect(popSpan()).to.deep.equal({
+      traceId: rootId.traceId,
+      id: rootId.spanId,
+      kind: 'CLIENT',
+      // there's no duration here as start timestamp was lost due to the flush
+      annotations: [{timestamp: 3, value: 'finish'}],
+      // note: default tags are intentionally not redundantly copied
+      tags: {
+        error: 'timeout'
       }
     });
 

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -290,6 +290,7 @@ describe('Batch Recorder', () => {
 
     trace.recordServiceName('producer');
     trace.recordRpc('send-msg');
+    trace.recordAnnotation(new Annotation.LocalOperationStart());
     trace.recordAnnotation(new Annotation.LocalOperationStop());
 
     const loggedSpan = logSpan.getCall(0).args[0];
@@ -315,6 +316,7 @@ describe('Batch Recorder', () => {
       }));
       trace.recordServiceName('producer');
       trace.recordRpc('send-msg');
+      trace.recordAnnotation(new Annotation.LocalOperationStart());
       trace.recordAnnotation(new Annotation.LocalOperationStop());
 
       const loggedSpan = logSpan.getCall(0).args[0];


### PR DESCRIPTION
Before, we conflated timing around data timeouts with span lifecycle
(eg start/finish). This caused some confusion in the code, and a lot of
redundant clock calls. This refactors the code to only use timestamps
from the events, and only the authoritative ones for purposes of start
and finish.

Moreover, this attempts to compensate for data lost when a flush happens
between start and finish by backfilling a "finish" annotation in such
case. With better code structure in finish callbacks, we should even be
able to eliminate this (by redundantly replaying the span's start event
on an async finish callback). For now, it will correct the problems of
flush better than most libraries do, because the UI will interpret any
annotation to backfill a duration.