### PR TITLE
Stops encouraging serviceName overrides

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/README.md
+++ b/packages/zipkin-instrumentation-axiosjs/README.md
@@ -27,7 +27,7 @@ const localServiceName = 'service-a'; // name of this application
 const tracer = new Tracer({ ctxImpl, recorder, localServiceName });
 
 const remoteServiceName = 'weather-api';
-const zipkinAxios = wrapAxios(axios, { tracer, serviceName: localServiceName, remoteServiceName });
+const zipkinAxios = wrapAxios(axios, { tracer, remoteServiceName });
 
 zipkinAxios.get('/user?ID=12345')
   .then(function (response) {
@@ -46,11 +46,7 @@ zipkinAxios.get('/user?ID=12345')
     timeout: 1000,
     headers: {'X-Custom-Header': 'foobar'}
 });
-  axiosInstance = wrapAxios(axiosInstance, {
-    tracer,
-    serviceName: localServiceName,
-    remoteServiceName
-  });
+  axiosInstance = wrapAxios(axiosInstance, {tracer, remoteServiceName});
 ```
 
 

--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -39,7 +39,11 @@ describe('axios instrumentation - integration test', () => {
 
   beforeEach(() => {
     spans = [];
-    tracer = new Tracer({ctxImpl: new ExplicitContext(), recorder: newSpanRecorder(spans)});
+    tracer = new Tracer({
+      ctxImpl: new ExplicitContext(),
+      localServiceName: serviceName,
+      recorder: newSpanRecorder(spans)
+    });
   });
 
   function popSpan() {
@@ -52,7 +56,7 @@ describe('axios instrumentation - integration test', () => {
       timeout: 300 // this avoids flakes in CI
     });
 
-    return wrapAxios(instance, {tracer, serviceName, remoteServiceName});
+    return wrapAxios(instance, {tracer, remoteServiceName});
   }
 
   function url(path) {

--- a/packages/zipkin-instrumentation-axiosjs/test/unitTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/unitTest.js
@@ -12,17 +12,17 @@ describe('axios instrumentation - unit test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    tracer = new Tracer({recorder, ctxImpl});
+    tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
   });
   it('should return an axios instance when pass axios', done => {
-    const axiosInstance = wrapAxios(axios, {tracer, serviceName, remoteServiceName});
+    const axiosInstance = wrapAxios(axios, {tracer, remoteServiceName});
     expect(axiosInstance.create).to.equal(undefined);
     done();
   });
 
   it('should return itself when pass an axiosInstance', done => {
     const axiosInstance = axios.create();
-    const zipkinAxiosInstance = wrapAxios(axiosInstance, {tracer, serviceName, remoteServiceName});
+    const zipkinAxiosInstance = wrapAxios(axiosInstance, {tracer, remoteServiceName});
     expect(axiosInstance).to.equal(zipkinAxiosInstance);
     done();
   });

--- a/packages/zipkin-instrumentation-connect/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-connect/test/integrationTest.js
@@ -8,12 +8,12 @@ const middleware = require('../src/middleware');
 const https = require('https');
 const fs = require('fs');
 
-const serviceName = 'service-a';
+const serviceName = 'weather-app';
 const testSetup = () => {
   const record = sinon.spy();
   const recorder = {record};
   const ctxImpl = new ExplicitContext();
-  const tracer = new Tracer({recorder, ctxImpl});
+  const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
   return {record, recorder, ctxImpl, tracer};
 };
 
@@ -23,7 +23,7 @@ describe('restify middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         ctxImpl.scoped(() => {
           // Use setTimeout to test that the trace context is propagated into the callback
@@ -58,7 +58,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -96,7 +96,7 @@ describe('restify middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -140,7 +140,7 @@ describe('restify middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -173,7 +173,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -217,7 +217,7 @@ describe('express middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -246,7 +246,7 @@ describe('express middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -284,7 +284,7 @@ describe('express middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -327,7 +327,7 @@ describe('express middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -355,7 +355,7 @@ describe('express middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -399,7 +399,7 @@ describe('connect middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = connect();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.use('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -432,7 +432,7 @@ describe('connect middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -470,7 +470,7 @@ describe('connect middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = connect();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.use('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -514,7 +514,7 @@ describe('connect middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = connect();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.use('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -547,7 +547,7 @@ describe('connect middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -595,7 +595,7 @@ describe('connect middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = connect();
-      app.use(middleware({tracer, serviceName}));
+      app.use(middleware({tracer}));
       app.use('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();

--- a/packages/zipkin-instrumentation-connect/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-connect/test/integrationTest.js
@@ -58,7 +58,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -173,7 +173,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -246,7 +246,7 @@ describe('express middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -355,7 +355,7 @@ describe('express middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -432,7 +432,7 @@ describe('connect middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -547,7 +547,7 @@ describe('connect middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -39,7 +39,11 @@ describe('CujoJS/rest instrumentation - integration test', () => {
 
   beforeEach(() => {
     spans = [];
-    tracer = new Tracer({ctxImpl: new ExplicitContext(), recorder: newSpanRecorder(spans)});
+    tracer = new Tracer({
+      ctxImpl: new ExplicitContext(),
+      localServiceName: serviceName,
+      recorder: newSpanRecorder(spans)
+    });
   });
 
   function popSpan() {
@@ -48,7 +52,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
   }
 
   function getClient() {
-    return rest.wrap(restInterceptor, {tracer, serviceName, remoteServiceName});
+    return rest.wrap(restInterceptor, {tracer, remoteServiceName});
   }
 
   function url(path) {

--- a/packages/zipkin-instrumentation-express/README.md
+++ b/packages/zipkin-instrumentation-express/README.md
@@ -31,11 +31,10 @@ const proxy = require('express-http-proxy');
 
 const ctxImpl = new ExplicitContext();
 const recorder = new ConsoleRecorder();
-const tracer = new Tracer({ctxImpl, recorder});
-const serviceName = 'weather-app';
+const tracer = new Tracer({ctxImpl, localServiceName: 'weather-app', recorder});
 const remoteServiceName = 'weather-api';
 
-const zipkinProxy = wrapExpressHttpProxy(proxy, {tracer, serviceName, remoteServiceName});
+const zipkinProxy = wrapExpressHttpProxy(proxy, {tracer, remoteServiceName});
 
 app.use('/api/weather', zipkinProxy('http://api.weather.com', {
   decorateRequest: (proxyReq, originalReq) => proxyReq.method = 'POST' // You can use express-http-proxy options as usual
@@ -50,11 +49,10 @@ const proxy = require('express-http-proxy');
 
 const ctxImpl = new CLSContext();
 const recorder = new ConsoleRecorder();
-const tracer = new Tracer({ctxImpl, recorder});
-const serviceName = 'weather-app';
+const tracer = new Tracer({ctxImpl, localServiceName: 'weather-app', recorder});
 const remoteServiceName = 'weather-api';
 
-const zipkinProxy = wrapExpressHttpProxy(proxy, {tracer, serviceName, remoteServiceName});
+const zipkinProxy = wrapExpressHttpProxy(proxy, {tracer, remoteServiceName});
 
-app.use('/api/weather', expressMiddleware({tracer, serviceName}), zipkinProxy('http://api.weather.com'));
+app.use('/api/weather', expressMiddleware({tracer}), zipkinProxy('http://api.weather.com'));
 ```

--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -7,7 +7,7 @@ function getPathnameFromPath(path) {
 }
 
 class ExpressHttpProxyInstrumentation {
-  constructor({tracer, serviceName, remoteServiceName}) {
+  constructor({tracer, serviceName = tracer.localEndpoint.serviceName, remoteServiceName}) {
     this.tracer = tracer;
     this.serviceName = serviceName;
     this.remoteServiceName = remoteServiceName;
@@ -79,11 +79,8 @@ function wrapProxy(proxy, {tracer, serviceName, remoteServiceName}) {
       };
     }
 
-    const instrumentation = new ExpressHttpProxyInstrumentation({
-      tracer,
-      serviceName,
-      remoteServiceName
-    });
+    const instrumentation =
+      new ExpressHttpProxyInstrumentation({tracer, serviceName, remoteServiceName});
 
     const wrappedOptions = options;
 

--- a/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
@@ -49,7 +49,7 @@ describe('express middleware - integration test', () => {
               .to.equal(originalSpanId));
 
             expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-            expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+            expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
             expect(annotations[1].annotation.annotationType).to.equal('Rpc');
             expect(annotations[1].annotation.name).to.equal('POST');
@@ -134,7 +134,7 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = express();
@@ -181,7 +181,7 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     function step(num) {
       return new Promise((resolve) => {
@@ -263,7 +263,7 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = express();

--- a/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
@@ -5,18 +5,17 @@ const express = require('express');
 const middleware = require('../src/expressMiddleware');
 
 describe('express middleware - integration test', () => {
+  const serviceName = 'weather-app';
+
   it('should record request & response annotations', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({
-        tracer,
-        serviceName: 'service-a'
-      }));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -50,7 +49,7 @@ describe('express middleware - integration test', () => {
               .to.equal(originalSpanId));
 
             expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-            expect(annotations[0].annotation.serviceName).to.equal('service-a');
+            expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
             expect(annotations[1].annotation.annotationType).to.equal('Rpc');
             expect(annotations[1].annotation.name).to.equal('POST');
@@ -93,10 +92,7 @@ describe('express middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({
-        tracer,
-        serviceName: 'service-a'
-      }));
+      app.use(middleware({tracer}));
       app.get('/foo', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -138,11 +134,11 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({tracer, serviceName: 'service-a'}));
+      app.use(middleware({tracer}));
 
       app.get('/foo/:id', (req, res) => {
         // Use setTimeout to test that the trace context is propagated into the callback
@@ -185,7 +181,7 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     function step(num) {
       return new Promise((resolve) => {
@@ -200,10 +196,7 @@ describe('express middleware - integration test', () => {
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({
-        tracer,
-        serviceName: 'service-a'
-      }));
+      app.use(middleware({tracer}));
 
       app.get('/foo', (req, res) => step(1)
         .then(() => step(2))
@@ -270,11 +263,11 @@ describe('express middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = express();
-      app.use(middleware({tracer, serviceName: 'service-a'}));
+      app.use(middleware({tracer}));
 
       app.get('/error', (req, res) => {
         tracer.recordBinary('message', 'hello from within app');

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -8,6 +8,7 @@ const wrapProxy = require('../src/wrapExpressHttpProxy');
 const middleware = require('../src/expressMiddleware');
 
 describe('express http proxy instrumentation - integration test', () => {
+  const serviceName = 'weather-app';
   const api = express();
   api.use('/weather', (req, res) => {
     res.status(202).json({
@@ -20,10 +21,9 @@ describe('express http proxy instrumentation - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
       const remoteServiceName = 'weather-api';
 
       const apiServer = api.listen(0, () => {
@@ -31,7 +31,7 @@ describe('express http proxy instrumentation - integration test', () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
 
-        const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
+        const zipkinProxy = wrapProxy(proxy, {tracer, remoteServiceName});
 
         app.use(zipkinProxy(`${apiHost}:${apiPort}`, {
           decorateRequest: (proxyReq) => {
@@ -96,10 +96,9 @@ describe('express http proxy instrumentation - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
       const remoteServiceName = 'weather-api';
 
       const apiServer = api.listen(0, () => {
@@ -107,7 +106,7 @@ describe('express http proxy instrumentation - integration test', () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
 
-        const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
+        const zipkinProxy = wrapProxy(proxy, {tracer, remoteServiceName});
 
         app.use(zipkinProxy(`${apiHost}:${apiPort}`));
 
@@ -161,10 +160,9 @@ describe('express http proxy instrumentation - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new CLSContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     tracer.scoped(() => {
-      const serviceName = 'weather-app';
       const remoteServiceName = 'weather-api';
 
       const apiServer = api.listen(0, () => {
@@ -172,9 +170,9 @@ describe('express http proxy instrumentation - integration test', () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
 
-        const zipkinProxy = wrapProxy(proxy, {tracer, serviceName, remoteServiceName});
+        const zipkinProxy = wrapProxy(proxy, {tracer, remoteServiceName});
 
-        app.use(middleware({tracer, serviceName}), zipkinProxy(`${apiHost}:${apiPort}`, {
+        app.use(middleware({tracer}), zipkinProxy(`${apiHost}:${apiPort}`, {
           decorateRequest: (proxyReq) => {
             const modifiedReq = proxyReq;
             modifiedReq.method = 'POST';

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -63,7 +63,7 @@ describe('express http proxy instrumentation - integration test', () => {
                   .to.have.lengthOf(16));
 
               expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
               expect(annotations[1].annotation.annotationType).to.equal('Rpc');
               expect(annotations[1].annotation.name).to.equal('POST');
@@ -127,7 +127,7 @@ describe('express http proxy instrumentation - integration test', () => {
                   .to.have.lengthOf(16));
 
               expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
               expect(annotations[1].annotation.annotationType).to.equal('Rpc');
               expect(annotations[1].annotation.name).to.equal('GET');
@@ -206,7 +206,7 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations.map(ann => ann.traceId.spanId)).to.contain('bbb');
 
               expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
               expect(annotations[1].annotation.annotationType).to.equal('Rpc');
               expect(annotations[1].annotation.name).to.equal('PUT');
@@ -220,7 +220,7 @@ describe('express http proxy instrumentation - integration test', () => {
               expect(annotations[4].annotation.annotationType).to.equal('LocalAddr');
 
               expect(annotations[5].annotation.annotationType).to.equal('ServiceName');
-              expect(annotations[5].annotation.serviceName).to.equal('weather-app');
+              expect(annotations[5].annotation.serviceName).to.equal(serviceName);
 
               expect(annotations[6].annotation.annotationType).to.equal('Rpc');
               expect(annotations[6].annotation.name).to.equal('POST');

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -5,6 +5,8 @@ const sinon = require('sinon');
 const wrapFetch = require('../src/wrapFetch');
 
 describe('wrapFetch', () => {
+  const serviceName = 'weather-app';
+
   before(function(done) {
     const app = express();
     app.post('/user', (req, res) => res.status(202).json({
@@ -26,13 +28,9 @@ describe('wrapFetch', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
-    const fetch = wrapFetch(nodeFetch, {
-      tracer,
-      serviceName: 'caller',
-      remoteServiceName: 'callee'
-    });
+    const fetch = wrapFetch(nodeFetch, {tracer, remoteServiceName: 'callee'});
 
     ctxImpl.scoped(() => {
       const id = tracer.createChildId();
@@ -53,7 +51,7 @@ describe('wrapFetch', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal(spanId));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('caller');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -86,7 +84,7 @@ describe('wrapFetch', () => {
 
   it('should not throw when using fetch without options', function(done) {
     const tracer = createNoopTracer();
-    const fetch = wrapFetch(nodeFetch, {serviceName: 'user-service', tracer});
+    const fetch = wrapFetch(nodeFetch, {tracer});
 
     const path = `http://127.0.0.1:${this.port}/user`;
     fetch(path)
@@ -99,7 +97,7 @@ describe('wrapFetch', () => {
 
   it('should not throw when using fetch with a request object', function(done) {
     const tracer = createNoopTracer();
-    const fetch = wrapFetch(nodeFetch, {serviceName: 'user-service', tracer});
+    const fetch = wrapFetch(nodeFetch, {tracer});
 
     const path = `http://127.0.0.1:${this.port}/user`;
     const request = {url: path};
@@ -115,13 +113,9 @@ describe('wrapFetch', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
-    const fetch = wrapFetch(nodeFetch, {
-      tracer,
-      serviceName: 'caller',
-      remoteServiceName: 'callee'
-    });
+    const fetch = wrapFetch(nodeFetch, {tracer, remoteServiceName: 'callee'});
 
     ctxImpl.scoped(() => {
       const id = tracer.createChildId();
@@ -141,7 +135,7 @@ describe('wrapFetch', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal(spanId));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('caller');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -8,7 +8,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
@@ -21,7 +21,7 @@ describe('hapi middleware - integration test', () => {
       });
       server.register({
         plugin: middleware,
-        options: {tracer, serviceName: 'service-a'}
+        options: {tracer}
       })
         .then(() => {
           const method = 'POST';
@@ -39,7 +39,7 @@ describe('hapi middleware - integration test', () => {
           annotations.forEach((ann) => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -70,13 +70,13 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
       server.register({
         plugin: middleware,
-        options: {tracer, serviceName: 'service-a'}
+        options: {tracer}
       })
         .then(() => {
           const method = 'POST';
@@ -100,7 +100,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
@@ -114,7 +114,7 @@ describe('hapi middleware - integration test', () => {
       });
       server.register({
         plugin: middleware,
-        options: {tracer, serviceName: 'service-a'}
+        options: {tracer}
       })
         .then(() => {
           const method = 'GET';
@@ -140,7 +140,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
     const PAUSE_TIME_MILLIS = 100;
 
     ctxImpl.scoped(() => {
@@ -160,7 +160,7 @@ describe('hapi middleware - integration test', () => {
 
       server.register({
         plugin: middleware,
-        options: {tracer, serviceName: 'service-a'}
+        options: {tracer}
       })
         .then(() => {
           const method = 'POST';

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -4,11 +4,13 @@ const Hapi = require('hapi');
 const middleware = require('../src/hapiMiddleware');
 
 describe('hapi middleware - integration test', () => {
+  const serviceName = 'weather-app';
+
   it('should receive trace info from the client', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
@@ -39,7 +41,7 @@ describe('hapi middleware - integration test', () => {
           annotations.forEach((ann) => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -70,7 +72,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
@@ -100,7 +102,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const server = new Hapi.Server();
@@ -140,7 +142,7 @@ describe('hapi middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, localServiceName: 'weather-app', ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
     const PAUSE_TIME_MILLIS = 100;
 
     ctxImpl.scoped(() => {

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -32,7 +32,7 @@ describe('request instrumentation - integration test', () => {
     record = sinon.spy();
     recorder = {record};
     ctxImpl = new ExplicitContext();
-    tracer = new Tracer({recorder, ctxImpl});
+    tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
     rootId = tracer.createRootId();
     tracer.setId(rootId);
   });
@@ -42,7 +42,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest.get(url, () => {
@@ -86,7 +86,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest(url, () => {
@@ -130,7 +130,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({url}, () => {
@@ -174,7 +174,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({
@@ -220,7 +220,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300`;
         zipkinRequest({url}).on('response', () => {
@@ -265,7 +265,7 @@ describe('request instrumentation - integration test', () => {
       const apiServer = api.listen(0, () => {
         const apiPort = apiServer.address().port;
         const apiHost = '127.0.0.1';
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const urlPath = '/doesNotExist';
         const url = `http://${apiHost}:${apiPort}${urlPath}`;
         zipkinRequest({url, timeout: 100}).on('response', () => {
@@ -315,7 +315,7 @@ describe('request instrumentation - integration test', () => {
   it('should report request.error when service does not exist', done => {
     tracer.scoped(() => {
       api.listen(0, () => {
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
         const host = 'bad.invalid.url';
         const url = `http://${host}`;
         zipkinRequest({url, timeout: 5000}).on('error', () => {
@@ -371,7 +371,7 @@ describe('request instrumentation - integration test', () => {
         const urlPath = '/weather';
         const url = `http://${apiHost}:${apiPort}${urlPath}?index=10&count=300&delay=10`;
 
-        const wrapped = promisify(wrapRequest(request, {tracer, serviceName, remoteServiceName}));
+        const wrapped = promisify(wrapRequest(request, {tracer, remoteServiceName}));
 
         const promise1 = wrapped(url);
         const promise2 = wrapped(url);
@@ -419,7 +419,7 @@ describe('request instrumentation - integration test', () => {
         const urlpathDoesNotExist = '/doesNotExist';
         const urlDoesNotExist = `http://${apiHost}:${apiPort}${urlpathDoesNotExist}?index=10&count=300`;
 
-        const zipkinRequest = wrapRequest(request, {tracer, serviceName, remoteServiceName});
+        const zipkinRequest = wrapRequest(request, {tracer, remoteServiceName});
 
         zipkinRequest.get(url, () => {
           zipkinRequest.get(urlDoesNotExist, () => {

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -5,18 +5,17 @@ const restify = require('restify');
 const middleware = require('../src/restifyMiddleware');
 
 describe('restify middleware - integration test', () => {
+  const serviceName = 'weather-app';
+
   it('should receive trace info from the client', done => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({
-        tracer,
-        serviceName: 'weather-app'
-      }));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -49,7 +48,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -86,14 +85,11 @@ describe('restify middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({
-        tracer,
-        serviceName: 'weather-app'
-      }));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -136,14 +132,11 @@ describe('restify middleware - integration test', () => {
     const record = sinon.spy();
     const recorder = {record};
     const ctxImpl = new ExplicitContext();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     ctxImpl.scoped(() => {
       const app = restify.createServer();
-      app.use(middleware({
-        tracer,
-        serviceName: 'weather-app'
-      }));
+      app.use(middleware({tracer}));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
         const ctx = ctxImpl.getContext();
@@ -176,7 +169,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+          expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -15,7 +15,7 @@ describe('restify middleware - integration test', () => {
       const app = restify.createServer();
       app.use(middleware({
         tracer,
-        serviceName: 'service-a'
+        serviceName: 'weather-app'
       }));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
@@ -49,7 +49,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');
@@ -92,7 +92,7 @@ describe('restify middleware - integration test', () => {
       const app = restify.createServer();
       app.use(middleware({
         tracer,
-        serviceName: 'service-a'
+        serviceName: 'weather-app'
       }));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
@@ -142,7 +142,7 @@ describe('restify middleware - integration test', () => {
       const app = restify.createServer();
       app.use(middleware({
         tracer,
-        serviceName: 'service-a'
+        serviceName: 'weather-app'
       }));
       app.post('/foo', (req, res, next) => {
         // Use setTimeout to test that the trace context is propagated into the callback
@@ -176,7 +176,7 @@ describe('restify middleware - integration test', () => {
           annotations.forEach(ann => expect(ann.traceId.spanId).to.equal('bbb'));
 
           expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-          expect(annotations[0].annotation.serviceName).to.equal('service-a');
+          expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
           expect(annotations[1].annotation.annotationType).to.equal('Rpc');
           expect(annotations[1].annotation.name).to.equal('POST');

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -325,7 +325,7 @@ declare namespace zipkin {
     }
 
     class HttpClient {
-      constructor(args: { tracer: Tracer, serviceName: string, remoteServiceName?: string });
+      constructor(args: { tracer: Tracer, serviceName?: string, remoteServiceName?: string });
 
       recordRequest<T>(
         request: T,

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -25,7 +25,7 @@ describe('Http Server Instrumentation', () => {
   it('should create traceId', () => {
     const {record, recorder, ctxImpl} = setupTest();
     const tracer = new Tracer({recorder, ctxImpl});
-    const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port: 80});
+    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port: 80});
     const url = '/foo';
 
     ctxImpl.scoped(() => {
@@ -46,7 +46,7 @@ describe('Http Server Instrumentation', () => {
     annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
     expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-    expect(annotations[0].annotation.serviceName).to.equal('service-a');
+    expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
     expect(annotations[1].annotation.annotationType).to.equal('Rpc');
     expect(annotations[1].annotation.name).to.equal('POST');
@@ -89,7 +89,7 @@ describe('Http Server Instrumentation', () => {
       const tracer = new Tracer({recorder, ctxImpl});
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
 
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
@@ -106,7 +106,7 @@ describe('Http Server Instrumentation', () => {
       annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(true));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-      expect(annotations[0].annotation.serviceName).to.equal('service-a');
+      expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
       expect(annotations[1].annotation.annotationType).to.equal('Rpc');
       expect(annotations[1].annotation.name).to.equal('POST');
@@ -139,7 +139,7 @@ describe('Http Server Instrumentation', () => {
       const {port, url} = setupServerUrl();
       const instrumentation = new HttpServer({
         tracer,
-        serviceName: 'service-a',
+        serviceName: 'weather-app',
         port
       });
 
@@ -159,7 +159,7 @@ describe('Http Server Instrumentation', () => {
       annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-      expect(annotations[0].annotation.serviceName).to.equal('service-a');
+      expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
       expect(annotations[1].annotation.annotationType).to.equal('Rpc');
       expect(annotations[1].annotation.name).to.equal('POST');
@@ -217,7 +217,7 @@ describe('Http Server Instrumentation', () => {
       const tracer = new Tracer({recorder, ctxImpl});
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
 
 
       const readHeader = function(name) {
@@ -238,7 +238,7 @@ describe('Http Server Instrumentation', () => {
         annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
         expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-        expect(annotations[0].annotation.serviceName).to.equal('service-a');
+        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
 
         expect(annotations[1].annotation.annotationType).to.equal('Rpc');
         expect(annotations[1].annotation.name).to.equal('POST');
@@ -274,7 +274,7 @@ describe('Http Server Instrumentation', () => {
     const port = 80;
     const host = '127.0.0.1';
     const urlPath = '/foo';
-    const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
     const url = `http://${host}:${port}${urlPath}?abc=123`;
     ctxImpl.scoped(() => {
       const id = instrumentation.recordRequest('GET', url, () => None);
@@ -293,7 +293,7 @@ describe('Http Server Instrumentation', () => {
     const tracer = new Tracer({recorder, ctxImpl});
 
     const port = 80;
-    const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
     const url = `http://127.0.0.1:${port}`;
     const traceId = '863ac35c9f6413ad48485a3953bb6124';
     const headers = {
@@ -333,7 +333,7 @@ describe('Http Server Instrumentation', () => {
     headersCases.forEach(headers => {
       const port = 80;
       const url = `http://127.0.0.1:${port}`;
-      const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
       };
@@ -360,7 +360,7 @@ describe('Http Server Instrumentation', () => {
       };
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'service-a', port});
+      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
       };
@@ -376,7 +376,7 @@ describe('Http Server Instrumentation', () => {
     const tracer = new Tracer({recorder, ctxImpl});
     const instrumentation = new HttpServer({
       tracer,
-      serviceName: 'service-a',
+      serviceName: 'weather-app',
       host: '1.1.1.1',
       port: 80
     });
@@ -398,7 +398,7 @@ describe('Http Server Instrumentation', () => {
     const tracer = new Tracer({recorder, ctxImpl});
     const instrumentation = new HttpServer({
       tracer,
-      serviceName: 'service-a',
+      serviceName: 'weather-app',
       port: 80
     });
 

--- a/packages/zipkin/test/httpServerInstrumentation.test.js
+++ b/packages/zipkin/test/httpServerInstrumentation.test.js
@@ -22,10 +22,12 @@ const setupServerUrl = () => {
 };
 
 describe('Http Server Instrumentation', () => {
+  const serviceName = 'weather-app';
+
   it('should create traceId', () => {
     const {record, recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
-    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port: 80});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
+    const instrumentation = new HttpServer({tracer, port: 80});
     const url = '/foo';
 
     ctxImpl.scoped(() => {
@@ -46,7 +48,7 @@ describe('Http Server Instrumentation', () => {
     annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
     expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-    expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+    expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
     expect(annotations[1].annotation.annotationType).to.equal('Rpc');
     expect(annotations[1].annotation.name).to.equal('POST');
@@ -89,7 +91,7 @@ describe('Http Server Instrumentation', () => {
       const tracer = new Tracer({recorder, ctxImpl});
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
+      const instrumentation = new HttpServer({tracer, serviceName, port});
 
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
@@ -106,7 +108,7 @@ describe('Http Server Instrumentation', () => {
       annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(true));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-      expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+      expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
       expect(annotations[1].annotation.annotationType).to.equal('Rpc');
       expect(annotations[1].annotation.name).to.equal('POST');
@@ -134,14 +136,11 @@ describe('Http Server Instrumentation', () => {
   traceContextCases.forEach((headers, index) => {
     it(`should should not join spans if join not supported case ${index}`, () => {
       const {record, recorder, ctxImpl} = setupTest();
-      const tracer = new Tracer({recorder, ctxImpl, supportsJoin: false});
+      const supportsJoin = false;
+      const tracer = new Tracer({recorder, ctxImpl, localServiceName: serviceName, supportsJoin});
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({
-        tracer,
-        serviceName: 'weather-app',
-        port
-      });
+      const instrumentation = new HttpServer({tracer, port});
 
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
@@ -159,7 +158,7 @@ describe('Http Server Instrumentation', () => {
       annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
       expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-      expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+      expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
       expect(annotations[1].annotation.annotationType).to.equal('Rpc');
       expect(annotations[1].annotation.name).to.equal('POST');
@@ -214,11 +213,10 @@ describe('Http Server Instrumentation', () => {
 
     it(`should receive sampling flags from the client with ${caseName.join(', ')}`, () => {
       const {record, recorder, ctxImpl} = setupTest();
-      const tracer = new Tracer({recorder, ctxImpl});
+      const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
-
+      const instrumentation = new HttpServer({tracer, port});
 
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
@@ -238,7 +236,7 @@ describe('Http Server Instrumentation', () => {
         annotations.forEach(ann => expect(ann.traceId.isShared()).to.equal(false));
 
         expect(annotations[0].annotation.annotationType).to.equal('ServiceName');
-        expect(annotations[0].annotation.serviceName).to.equal('weather-app');
+        expect(annotations[0].annotation.serviceName).to.equal(serviceName);
 
         expect(annotations[1].annotation.annotationType).to.equal('Rpc');
         expect(annotations[1].annotation.name).to.equal('POST');
@@ -269,12 +267,12 @@ describe('Http Server Instrumentation', () => {
 
   it('should properly report the path excluding the query string', () => {
     const {record, recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     const port = 80;
     const host = '127.0.0.1';
     const urlPath = '/foo';
-    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
+    const instrumentation = new HttpServer({tracer, port});
     const url = `http://${host}:${port}${urlPath}?abc=123`;
     ctxImpl.scoped(() => {
       const id = instrumentation.recordRequest('GET', url, () => None);
@@ -290,10 +288,10 @@ describe('Http Server Instrumentation', () => {
 
   it('should accept a 128bit X-B3-TraceId', () => {
     const {record, recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     const port = 80;
-    const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
+    const instrumentation = new HttpServer({tracer, port});
     const url = `http://127.0.0.1:${port}`;
     const traceId = '863ac35c9f6413ad48485a3953bb6124';
     const headers = {
@@ -315,7 +313,7 @@ describe('Http Server Instrumentation', () => {
 
   it('should tolerate boolean literals for sampled header received from the client', () => {
     const {recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
 
     const headersCases = [
       {
@@ -333,7 +331,7 @@ describe('Http Server Instrumentation', () => {
     headersCases.forEach(headers => {
       const port = 80;
       const url = `http://127.0.0.1:${port}`;
-      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
+      const instrumentation = new HttpServer({tracer, serviceName, port});
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
       };
@@ -352,7 +350,7 @@ describe('Http Server Instrumentation', () => {
   samplerCases.forEach(sampler => {
     it(`should use sampler to calculate sampled value if missing in header (${sampler})`, () => {
       const {recorder, ctxImpl} = setupTest();
-      const tracer = new Tracer({recorder, ctxImpl, sampler});
+      const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl, sampler});
 
       const headers = {
         'X-B3-TraceId': 'aaa',
@@ -360,7 +358,7 @@ describe('Http Server Instrumentation', () => {
       };
 
       const {port, url} = setupServerUrl();
-      const instrumentation = new HttpServer({tracer, serviceName: 'weather-app', port});
+      const instrumentation = new HttpServer({tracer, serviceName, port});
       const readHeader = function(name) {
         return headers[name] ? new Some(headers[name]) : None;
       };
@@ -373,10 +371,10 @@ describe('Http Server Instrumentation', () => {
 
   it('should allow the host to be overridden', () => {
     const {record, recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
     const instrumentation = new HttpServer({
       tracer,
-      serviceName: 'weather-app',
+      serviceName,
       host: '1.1.1.1',
       port: 80
     });
@@ -395,10 +393,10 @@ describe('Http Server Instrumentation', () => {
 
   it('should work if the host option is not defined', () => {
     const {record, recorder, ctxImpl} = setupTest();
-    const tracer = new Tracer({recorder, ctxImpl});
+    const tracer = new Tracer({recorder, localServiceName: serviceName, ctxImpl});
     const instrumentation = new HttpServer({
       tracer,
-      serviceName: 'weather-app',
+      serviceName,
       port: 80
     });
 


### PR DESCRIPTION
We continue to get support problems due to people overriding service
names incorrectly. There's rarely a valid reason to override what's in
the tracer. This stops us from doing it in tests and README files. We
should strongly consider removing the ability to override the
serviceName in v2 such as we do in other libraries, for the reason of
needless support burden.