### PR TITLE
Removes lodash to avoid distracting bot pull requests

### DIFF
--- a/packages/zipkin-instrumentation-kafkajs/package.json
+++ b/packages/zipkin-instrumentation-kafkajs/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "kafkajs": "^1.9.3",
     "zipkin": "^0.18.4",
-    "promise.prototype.finally": "3.1.0",
-    "lodash": "^4.17.11"
+    "promise.prototype.finally": "3.1.0"
   }
 }

--- a/packages/zipkin-instrumentation-request-promise/src/request.js
+++ b/packages/zipkin-instrumentation-request-promise/src/request.js
@@ -1,5 +1,4 @@
 import request from 'request-promise';
-import _ from 'lodash';
 import {Instrumentation} from 'zipkin';
 import {Deferred} from './promise';
 
@@ -92,13 +91,13 @@ const Request = class {
      * breaks zipkin scope
      */
     let cb = callback;
-    if (_.isFunction(callback)) {
+    if (typeof callback === 'function') {
       cb = this.tracer._ctxImpl._session.bind(callback);
     }
 
     const instance = this.httpRequest(options, cb);
 
-    if (_.isFunction(cb)) {
+    if (typeof cb === 'function') {
       return instance;
     }
     instance.then(defer.resolve, defer.reject);


### PR DESCRIPTION
We have almost no usage of lodash, and the usage we have isn't security
critical. This removes the lodash dependency to avoid having to look up
what unrelated problems exist when there's a security notice.

See #390
Fixes #391