### PR TITLE
Migrates fetch to v2 style assertions and ensures they run in a browser

### DIFF
--- a/packages/zipkin-instrumentation-fetch/package.json
+++ b/packages/zipkin-instrumentation-fetch/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --exit --require ../../test/helper.js",
+    "test": "mocha --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
+    "test-browser": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
This migrates the same tests used in Axios to fetch, notably deferring
loading of node-fetch in case we are running in a browser.