### PR TITLE
Fixes bug where Tracer.id sentinel value was ignored

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -41,11 +41,13 @@ declare namespace zipkin {
       log?: Console
     });
 
+    /** Returns the current trace ID or a sentinel value indicating its absence. */
     id: TraceId;
 
     scoped<V>(callback: () => V): V;
     local<V>(name: string, callback: () => V): V;
     createRootId(isSampled?: option.IOption<boolean>, isDebug?: boolean): TraceId;
+    /** Creates a child of the current trace ID or a new root span. */
     createChildId(): TraceId;
     letId<V>(traceId: TraceId, callback: () => V): V;
     setId(traceId: TraceId): void;

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -48,7 +48,9 @@ class Tracer {
       });
     }
     this._ctxImpl = ctxImpl;
-    this._sentinelTraceId = this.createRootId(false);
+    // The sentinel is used until there's a trace ID in scope.
+    // Technically, this ID should have been unsampled, but it can break code to change that now.
+    this._sentinelTraceId = this.createRootId();
     this._startTimestamp = now();
     this._startTick = hrtime();
     // only set defaultTags in recorders which know about it

--- a/packages/zipkin/src/tracer/index.js
+++ b/packages/zipkin/src/tracer/index.js
@@ -48,7 +48,7 @@ class Tracer {
       });
     }
     this._ctxImpl = ctxImpl;
-    this._defaultTraceId = this.createRootId();
+    this._sentinelTraceId = this.createRootId(false);
     this._startTimestamp = now();
     this._startTick = hrtime();
     // only set defaultTags in recorders which know about it
@@ -95,7 +95,7 @@ class Tracer {
       parentId = this._ctxImpl.getContext();
     }
 
-    if (this.isUndefinedOrNull(parentId)) {
+    if (parentId === this._sentinelTraceId || this.isUndefinedOrNull(parentId)) {
       return this.createRootId();
     }
 
@@ -169,7 +169,6 @@ class Tracer {
     if (!(traceId instanceof TraceId)) {
       throw new Error('Must be valid TraceId instance');
     }
-
     if (!this.supportsJoin) {
       return this.createChildId(traceId);
     }
@@ -188,8 +187,9 @@ class Tracer {
     this._ctxImpl.setContext(traceId);
   }
 
+  // Returns the current trace ID or a sentinel value indicating its absence.
   get id() {
-    return this._ctxImpl.getContext() || this._defaultTraceId;
+    return this._ctxImpl.getContext() || this._sentinelTraceId;
   }
 
   get localEndpoint() {

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -45,6 +45,22 @@ describe('Tracer', () => {
     });
   });
 
+  it('should consider sentinel id as root', () => {
+    const ctxImpl = new ExplicitContext();
+    const tracer = new Tracer({ctxImpl, recorder});
+
+    // There's currently no api to tell if there is a trace in progress or not.
+    // The only exposed mechanism is Tracer.id, which can return a sentinel value.
+    const sentinel = tracer.id;
+
+    ctxImpl.scoped(() => {
+      tracer.setId(sentinel);
+      const shouldBeRoot = tracer.createChildId();
+      // When createChildId is called with the sentinel, we expect a new root span
+      expect(shouldBeRoot.parentSpanId.getOrElse(true)).to.equal(true);
+    });
+  });
+
   it('should clear scope after letId', () => {
     const ctxImpl = new ExplicitContext();
     const tracer = new Tracer({ctxImpl, recorder});

--- a/packages/zipkin/test/trace.test.js
+++ b/packages/zipkin/test/trace.test.js
@@ -57,7 +57,7 @@ describe('Tracer', () => {
       tracer.setId(sentinel);
       const shouldBeRoot = tracer.createChildId();
       // When createChildId is called with the sentinel, we expect a new root span
-      expect(shouldBeRoot.parentSpanId.getOrElse(true)).to.equal(true);
+      expect(shouldBeRoot.parentSpanId.getOrElse(null)).to.equal(null);
     });
   });
 


### PR DESCRIPTION
The initial design of zipkin-js included a sentinel value on `Tracer.id`
that allows you to avoid needing to compare against null. The trouble is
that the sentinel was never compared against, and would result in root
spans appearing to be children of the sentinel. This is a bug because it
can lead to very large pseudo-traces. I'm sure the intent was to check
the sentinel before using it.