### PR TITLE
Fixes double-recording bug in superagent and rewrites tests to v2

### DIFF
--- a/packages/zipkin-instrumentation-superagent/package.json
+++ b/packages/zipkin-instrumentation-superagent/package.json
@@ -5,7 +5,7 @@
   "main": "lib/superagentPlugin.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --exit --require ../../test/helper.js",
+    "test": "mocha --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },
@@ -14,7 +14,7 @@
   "repository": "https://github.com/openzipkin/zipkin-js",
   "devDependencies": {
     "nock": "^9.0.14",
-    "superagent": "^4.0.0",
+    "superagent": "^5.1.0",
     "zipkin": "^0.18.4"
   }
 }


### PR DESCRIPTION
We were calling finish twice on 4xx and 5xx and didn't notice.