### PR TITLE
Fixes naming of get-multi and lack of error recording on memcached

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/package.json
+++ b/packages/zipkin-instrumentation-axiosjs/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
     "test-browser": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"

--- a/packages/zipkin-instrumentation-cujojs-rest/package.json
+++ b/packages/zipkin-instrumentation-cujojs-rest/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
     "test-browser": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"

--- a/packages/zipkin-instrumentation-fetch/package.json
+++ b/packages/zipkin-instrumentation-fetch/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless ../../karma.conf.js",
     "test-browser": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"

--- a/packages/zipkin-instrumentation-gotjs/package.json
+++ b/packages/zipkin-instrumentation-gotjs/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-grpc-client/package.json
+++ b/packages/zipkin-instrumentation-grpc-client/package.json
@@ -5,7 +5,7 @@
   "main": "lib/grpcClientInterceptor.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-kafkajs/package.json
+++ b/packages/zipkin-instrumentation-kafkajs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src -d lib",
     "pretest": "(docker kill kafkajs-test; docker rm kafkajs-test) 2>&-; docker run -d -p 9092:9092 --name kafkajs-test --hostname localhost openzipkin/zipkin-kafka && timeout 60 bash -c 'until echo > /dev/tcp/localhost/9092; do sleep 1; done'",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "posttest": "docker kill kafkajs-test && docker rm kafkajs-test",
     "prepublish": "npm run build"

--- a/packages/zipkin-instrumentation-memcached/README.md
+++ b/packages/zipkin-instrumentation-memcached/README.md
@@ -14,7 +14,7 @@ const tracer = new Tracer({ctxImpl, recorder, localServiceName});
 
 const connectionString = ''localhost:11211'';
 const options = {timeout: 1000};
-const memcached = new(zipkinClient(tracer, Memcached))(connectionString, options);
+const memcached = new (zipkinClient(tracer, Memcached))(connectionString, options);
 
 // Your application code here
 memcached.get('foo', (err, data) => {

--- a/packages/zipkin-instrumentation-memcached/package.json
+++ b/packages/zipkin-instrumentation-memcached/package.json
@@ -5,7 +5,7 @@
   "main": "lib/zipkinClient.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-memcached/package.json
+++ b/packages/zipkin-instrumentation-memcached/package.json
@@ -5,7 +5,7 @@
   "main": "lib/zipkinClient.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --exit --require ../../test/helper.js",
+    "test": "mocha --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-request-promise/package.json
+++ b/packages/zipkin-instrumentation-request-promise/package.json
@@ -5,7 +5,7 @@
   "main": "lib/request.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register --require @babel/polyfill",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register --require @babel/polyfill",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js --require @babel/register --require @babel/polyfill",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-request/package.json
+++ b/packages/zipkin-instrumentation-request/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-superagent/package.json
+++ b/packages/zipkin-instrumentation-superagent/package.json
@@ -5,7 +5,7 @@
   "main": "lib/superagentPlugin.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --require ../../test/helper.js --require @babel/register",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
This fixes the span name of get-multi and the lack of error recording on
memcached instrumentation. I noticed these problems when porting tests
v2 style.