### PR TITLE
Fixes some data glitches in postgres and converts tests to v2

### DIFF
--- a/packages/zipkin-instrumentation-postgres/package.json
+++ b/packages/zipkin-instrumentation-postgres/package.json
@@ -5,7 +5,7 @@
   "main": "lib/zipkinClient.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "mocha --exit --require ../../test/helper.js",
+    "test": "mocha --exit --require ../../test/helper.js --require @babel/register",
     "test-debug": "mocha --inspect-brk --exit --require ../../test/helper.js",
     "prepublish": "npm run build"
   },

--- a/packages/zipkin-instrumentation-postgres/src/zipkinClient.js
+++ b/packages/zipkin-instrumentation-postgres/src/zipkinClient.js
@@ -1,5 +1,7 @@
 const {Annotation, InetAddress} = require('zipkin');
 
+// TODO: function wrapPostgres(postgres, options = {})
+// as it is easy to get the service name and remote service name wrong when using positional args
 module.exports = function zipkinClient(
   tracer,
   Postgres,
@@ -13,7 +15,7 @@ module.exports = function zipkinClient(
   }
   function annotateError(id, error) {
     tracer.letId(id, () => {
-      tracer.recordBinary('error', error.toString());
+      tracer.recordBinary('error', error.message || String(error));
       tracer.recordAnnotation(new Annotation.ClientRecv());
     });
   }
@@ -45,7 +47,7 @@ module.exports = function zipkinClient(
       tracer.recordAnnotation(new Annotation.ServerAddr({
         serviceName: remoteServiceName,
         host: new InetAddress(this.host),
-        port: this.port
+        port: this.port.toString()
       }));
       tracer.recordRpc(`query ${this.database}`);
     });


### PR DESCRIPTION
There were a couple glitches notably port being tagged as a number, not
a string, and error being toString instead of preferring the message.
This was easy to see when the tests were ported to json v2.

Future work needs to happen because this code is unlike other database
instrumentation in so far as the span name is constant and there are no
tags except error.