### PR TITLE
add defaultTags to Tracer type

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -38,7 +38,8 @@ declare namespace zipkin {
       traceId128Bit?: boolean,
       localServiceName?: string,
       localEndpoint?: model.Endpoint,
-      log?: Console
+      log?: Console,
+      defaultTags?: {},
     });
 
     /** Returns the current trace ID or a sentinel value indicating its absence. */

--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -39,7 +39,7 @@ declare namespace zipkin {
       localServiceName?: string,
       localEndpoint?: model.Endpoint,
       log?: Console,
-      defaultTags?: {},
+      defaultTags?: {}
     });
 
     /** Returns the current trace ID or a sentinel value indicating its absence. */


### PR DESCRIPTION
please spin me a new release when you can.   I need this for a project at work.  it's just an option constructor argument in the Tracer type so we can pass the defaultTags.  I tested that it works.. i see my tags in all the traces ;)

closes https://github.com/openzipkin/zipkin-js/issues/413