### PR TITLE
feat(#381): adds zipkin-js.flush annotation for when a span is report…

### DIFF
--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -61,7 +61,7 @@ class BatchRecorder {
   /**
    * @constructor
    * @param {Object} options
-   * @property {Logger} logger logs the data to openZipkin
+   * @property {Logger} logger logs the data to zipkin server
    * @property {number} timeout timeout for span in microseconds
    */
   constructor({logger, timeout = defaultTimeout}) {
@@ -75,6 +75,10 @@ class BatchRecorder {
     const timer = setInterval(() => {
       this.partialSpans.forEach((span, id) => {
         if (_timedOut(span)) {
+          // the zipkin-js.flush annotation makes it explicit that
+          // the span has been reported because of a timeout, even
+          // when it is not finished yet (and thus enqueued for reporting)
+          span.delegate.addAnnotation(now(), 'zipkin-js.flush');
           this._writeSpan(id, span);
         }
       });

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -212,6 +212,9 @@ describe('Batch Recorder', () => {
       trace.recordAnnotation(new Annotation.ServerSend());
     });
 
+    const loggedSpan = logSpan.getCall(0).args[0];
+    expect(loggedSpan.annotations[0].value).to.equal('zipkin-js.flush');
+
     clock.uninstall();
   });
 

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -172,6 +172,11 @@ describe('Batch Recorder', () => {
       expect(loggedSpan.timestamp).to.equal(12345678000);
       expect(loggedSpan.duration).to.equal(123);
 
+      for (let i = 0; i < loggedSpan.annotations.length; i += 1) {
+        // we make sure it does not include the zipkin-js.flush annotation
+        expect(loggedSpan.annotations[i].value === 'zipkin-js.flush').to.equal(false);
+      }
+
       clock.uninstall();
     });
   });


### PR DESCRIPTION
This PR makes it possible to add a `zipkin-js.flush` annotation for a span when it is reported due to timeout (i.e. the span has been notified but the finish method was not called).

Closes #381 

Ping @adriancole 