### PR TITLE
Uses mocha shared behaviors to setup client integration test middleware

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -4,8 +4,8 @@ const axios = require('axios');
 const {
   expectB3Headers,
   expectSpan,
-  maybeMiddleware,
-  newSpanRecorder
+  newSpanRecorder,
+  setupTestServer
 } = require('../../../test/testFixture');
 const wrapAxios = require('../src/index');
 
@@ -14,24 +14,7 @@ describe('axios instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL = ''; // default to relative path, for browser-based tests
-
-  before((done) => {
-    const middleware = maybeMiddleware();
-    if (middleware !== null) {
-      server = middleware.listen(0, () => {
-        baseURL = `http://127.0.0.1:${server.address().port}`;
-        done();
-      });
-    } else { // Inside a browser
-      done();
-    }
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -59,7 +42,7 @@ describe('axios instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -14,7 +14,7 @@ describe('axios instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  setupTestServer();
+  const server = setupTestServer();
 
   let spans;
   let tracer;
@@ -41,10 +41,6 @@ describe('axios instrumentation - integration test', () => {
     return wrapAxios(instance, {tracer, remoteServiceName});
   }
 
-  function url(path) {
-    return `${global.baseURL}${path}?index=10&count=300`;
-  }
-
   function successSpan(path) {
     return ({
       name: 'get',
@@ -60,14 +56,14 @@ describe('axios instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path))
+    return getClient().get(server.url(path))
       .then(response => expectB3Headers(popSpan(), response.data));
   });
 
   it('should not interfere with errors that precede a call', (done) => {
     // Here we are passing a function instead of the value of it. This ensures our error callback
     // doesn't make assumptions about a span in progress: there won't be if there was a config error
-    getClient()(url)
+    getClient()(server.url)
       .then((response) => {
         done(new Error(`expected an invalid url parameter to error. status: ${response.status}`));
       })
@@ -84,19 +80,19 @@ describe('axios instrumentation - integration test', () => {
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path))
+    return getClient().get(server.url(path))
       .then(() => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should support options request', () => {
     const path = '/weather/wuhan';
-    return getClient()({url: url(path)})
+    return getClient()({url: server.url(path)})
       .then(() => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should report 404 in tags', (done) => {
     const path = '/pathno';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 404 response to error. status: ${response.status}`));
       })
@@ -118,7 +114,7 @@ describe('axios instrumentation - integration test', () => {
 
   it('should report 401 in tags', (done) => {
     const path = '/weather/securedTown';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 401 response to error. status: ${response.status}`));
       })
@@ -140,7 +136,7 @@ describe('axios instrumentation - integration test', () => {
 
   it('should report 500 in tags', (done) => {
     const path = '/weather/bagCity';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 500 response to error. status: ${response.status}`));
       })
@@ -188,8 +184,8 @@ describe('axios instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = client.get(url(beijing));
-    const getWuhanWeather = client.get(url(wuhan));
+    const getBeijingWeather = client.get(server.url(beijing));
+    const getWuhanWeather = client.get(server.url(wuhan));
 
     return getBeijingWeather.then(() => {
       getWuhanWeather.then(() => {
@@ -206,8 +202,8 @@ describe('axios instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = client.get(url(beijing));
-    const getWuhanWeather = client.get(url(wuhan));
+    const getBeijingWeather = client.get(server.url(beijing));
+    const getWuhanWeather = client.get(server.url(wuhan));
 
     return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
       // since these are parallel, we have an unexpected order

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -15,7 +15,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  setupTestServer();
+  const server = setupTestServer();
 
   let spans;
   let tracer;
@@ -38,10 +38,6 @@ describe('CujoJS/rest instrumentation - integration test', () => {
     return rest.wrap(restInterceptor, {tracer, remoteServiceName});
   }
 
-  function url(path) {
-    return `${global.baseURL}${path}?index=10&count=300`;
-  }
-
   function successSpan(path) {
     return ({
       name: 'get',
@@ -57,19 +53,19 @@ describe('CujoJS/rest instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return getClient()(url(path))
+    return getClient()(server.url(path))
       .then(response => expectB3Headers(popSpan(), JSON.parse(response.entity)));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return getClient()(url(path))
+    return getClient()(server.url(path))
       .then(() => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should report 404 in tags', () => {
     const path = '/pathno';
-    return getClient()(url(path))
+    return getClient()(server.url(path))
       .then(() => expectSpan(popSpan(), {
         name: 'get',
         kind: 'CLIENT',
@@ -85,7 +81,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
 
   it('should report 401 in tags', () => {
     const path = '/weather/securedTown';
-    return getClient()(url(path))
+    return getClient()(server.url(path))
       .then(() => expectSpan(popSpan(), {
         name: 'get',
         kind: 'CLIENT',
@@ -101,7 +97,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
 
   it('should report 500 in tags', () => {
     const path = '/weather/bagCity';
-    return getClient()(url(path))
+    return getClient()(server.url(path))
       .then(() => expectSpan(popSpan(), {
         name: 'get',
         kind: 'CLIENT',

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -3,10 +3,10 @@ const {ExplicitContext, Tracer} = require('zipkin');
 
 const rest = require('rest');
 const {
-  maybeMiddleware,
-  newSpanRecorder,
   expectB3Headers,
-  expectSpan
+  expectSpan,
+  newSpanRecorder,
+  setupTestServer
 } = require('../../../test/testFixture');
 const restInterceptor = require('../src/restInterceptor');
 
@@ -15,24 +15,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL = ''; // default to relative path, for browser-based tests
-
-  before((done) => {
-    const middleware = maybeMiddleware();
-    if (middleware !== null) {
-      server = middleware.listen(0, () => {
-        baseURL = `http://127.0.0.1:${server.address().port}`;
-        done();
-      });
-    } else { // Inside a browser
-      done();
-    }
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -56,7 +39,7 @@ describe('CujoJS/rest instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
@@ -3,10 +3,10 @@ const {ExplicitContext, Tracer} = require('zipkin');
 
 const got = require('got');
 const {
-  maybeMiddleware,
-  newSpanRecorder,
   expectB3Headers,
-  expectSpan
+  expectSpan,
+  newSpanRecorder,
+  setupTestServer,
 } = require('../../../test/testFixture');
 const wrapGot = require('../src/wrapGot');
 
@@ -14,19 +14,7 @@ describe('got instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL;
-
-  before((done) => {
-    server = maybeMiddleware().listen(0, () => {
-      baseURL = `http://127.0.0.1:${server.address().port}`;
-      done();
-    });
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -50,7 +38,7 @@ describe('got instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
@@ -14,7 +14,7 @@ describe('request-promise instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  setupTestServer();
+  const server = setupTestServer();
 
   let spans;
   let tracer;
@@ -38,10 +38,6 @@ describe('request-promise instrumentation - integration test', () => {
     return new ZipkinRequest(tracer, remoteServiceName);
   }
 
-  function url(path) {
-    return `${global.baseURL}${path}?index=10&count=300`;
-  }
-
   function successSpan(path) {
     return ({
       name: 'get',
@@ -57,19 +53,19 @@ describe('request-promise instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path))
+    return getClient().get(server.url(path))
       .then(response => expectB3Headers(popSpan(), JSON.parse(response)));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path))
+    return getClient().get(server.url(path))
       .then(() => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should report 404 in tags', (done) => {
     const path = '/pathno';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 404 response to error. status: ${response.status}`));
       })
@@ -91,7 +87,7 @@ describe('request-promise instrumentation - integration test', () => {
 
   it('should report 401 in tags', (done) => {
     const path = '/weather/securedTown';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 401 response to error. status: ${response.status}`));
       })
@@ -113,7 +109,7 @@ describe('request-promise instrumentation - integration test', () => {
 
   it('should report 500 in tags', (done) => {
     const path = '/weather/bagCity';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 500 response to error. status: ${response.status}`));
       })
@@ -163,8 +159,8 @@ describe('request-promise instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = client.get(url(beijing));
-    const getWuhanWeather = client.get(url(wuhan));
+    const getBeijingWeather = client.get(server.url(beijing));
+    const getWuhanWeather = client.get(server.url(wuhan));
 
     return getBeijingWeather.then(() => {
       getWuhanWeather.then(() => {
@@ -181,8 +177,8 @@ describe('request-promise instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = client.get(url(beijing));
-    const getWuhanWeather = client.get(url(wuhan));
+    const getBeijingWeather = client.get(server.url(beijing));
+    const getWuhanWeather = client.get(server.url(wuhan));
 
     return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
       // since these are parallel, we have an unexpected order

--- a/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
@@ -1,10 +1,10 @@
 const {expect} = require('chai');
 const {ExplicitContext, Tracer} = require('zipkin');
 const {
-  maybeMiddleware,
-  newSpanRecorder,
   expectB3Headers,
-  expectSpan
+  expectSpan,
+  newSpanRecorder,
+  setupTestServer
 } = require('../../../test/testFixture');
 
 const ZipkinRequest = require('../src/request').default;
@@ -14,19 +14,7 @@ describe('request-promise instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL;
-
-  before((done) => {
-    server = maybeMiddleware().listen(0, () => {
-      baseURL = `http://127.0.0.1:${server.address().port}`;
-      done();
-    });
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -51,7 +39,7 @@ describe('request-promise instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -3,10 +3,10 @@ const {ExplicitContext, Tracer} = require('zipkin');
 
 const request = require('request');
 const {
-  maybeMiddleware,
-  newSpanRecorder,
   expectB3Headers,
-  expectSpan
+  expectSpan,
+  newSpanRecorder,
+  setupTestServer
 } = require('../../../test/testFixture');
 const wrapRequest = require('../src/index');
 
@@ -14,19 +14,7 @@ describe('request instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL;
-
-  before((done) => {
-    server = maybeMiddleware().listen(0, () => {
-      baseURL = `http://127.0.0.1:${server.address().port}`;
-      done();
-    });
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -50,7 +38,7 @@ describe('request instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -14,7 +14,7 @@ describe('request instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  setupTestServer();
+  const server = setupTestServer();
 
   let spans;
   let tracer;
@@ -37,10 +37,6 @@ describe('request instrumentation - integration test', () => {
     return wrapRequest(request, {tracer, remoteServiceName});
   }
 
-  function url(path) {
-    return `${global.baseURL}${path}?index=10&count=300`;
-  }
-
   function successSpan(path) {
     return ({
       name: 'get',
@@ -56,23 +52,23 @@ describe('request instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path))
+    return getClient().get(server.url(path))
       .on('body', body => expectB3Headers(popSpan(), body));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return getClient().get(url(path), () => expectSpan(popSpan(), successSpan(path)));
+    return getClient().get(server.url(path), () => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should support options request', () => {
     const path = '/weather/wuhan';
-    return getClient()({url: url(path)}, () => expectSpan(popSpan(), successSpan(path)));
+    return getClient()({url: server.url(path)}, () => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should report 404 in tags', (done) => {
     const path = '/pathno';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .on('response', () => {
         expectSpan(popSpan(), {
           name: 'get',
@@ -92,7 +88,7 @@ describe('request instrumentation - integration test', () => {
 
   it('should report 401 in tags', (done) => {
     const path = '/weather/securedTown';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .on('response', () => {
         expectSpan(popSpan(), {
           name: 'get',
@@ -112,7 +108,7 @@ describe('request instrumentation - integration test', () => {
 
   it('should report 500 in tags', (done) => {
     const path = '/weather/bagCity';
-    getClient().get(url(path))
+    getClient().get(server.url(path))
       .on('response', () => {
         expectSpan(popSpan(), {
           name: 'get',
@@ -156,7 +152,7 @@ describe('request instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    client.get(url(beijing), () => client.get(url(wuhan), () => {
+    client.get(server.url(beijing), () => client.get(server.url(wuhan), () => {
       // since these are sequential, we should have an expected order
       expectSpan(popSpan(), successSpan(wuhan));
       expectSpan(popSpan(), successSpan(beijing));

--- a/packages/zipkin-instrumentation-superagent/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-superagent/test/integrationTest.js
@@ -16,7 +16,7 @@ describe('SuperAgent instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  setupTestServer();
+  const server = setupTestServer();
 
   let spans;
   let tracer;
@@ -39,10 +39,6 @@ describe('SuperAgent instrumentation - integration test', () => {
     return request.get(urlToGet).use(zipkinPlugin({tracer, remoteServiceName}));
   }
 
-  function url(path) {
-    return `${global.baseURL}${path}?index=10&count=300`;
-  }
-
   function successSpan(path) {
     return ({
       name: 'get',
@@ -58,19 +54,19 @@ describe('SuperAgent instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return get(url(path))
+    return get(server.url(path))
       .then(response => expectB3Headers(popSpan(), response.body));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return get(url(path))
+    return get(server.url(path))
       .then(() => expectSpan(popSpan(), successSpan(path)));
   });
 
   it('should report 404 in tags', (done) => {
     const path = '/pathno';
-    get(url(path))
+    get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 404 response to error. status: ${response.status}`));
       })
@@ -92,7 +88,7 @@ describe('SuperAgent instrumentation - integration test', () => {
 
   it('should report 401 in tags', (done) => {
     const path = '/weather/securedTown';
-    get(url(path))
+    get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 401 response to error. status: ${response.status}`));
       })
@@ -114,7 +110,7 @@ describe('SuperAgent instrumentation - integration test', () => {
 
   it('should report 500 in tags', (done) => {
     const path = '/weather/bagCity';
-    get(url(path))
+    get(server.url(path))
       .then((response) => {
         done(new Error(`expected status 500 response to error. status: ${response.status}`));
       })
@@ -160,8 +156,8 @@ describe('SuperAgent instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = get(url(beijing));
-    const getWuhanWeather = get(url(wuhan));
+    const getBeijingWeather = get(server.url(beijing));
+    const getWuhanWeather = get(server.url(wuhan));
 
     return getBeijingWeather.then(() => {
       getWuhanWeather.then(() => {
@@ -176,8 +172,8 @@ describe('SuperAgent instrumentation - integration test', () => {
     const beijing = '/weather/beijing';
     const wuhan = '/weather/wuhan';
 
-    const getBeijingWeather = get(url(beijing));
-    const getWuhanWeather = get(url(wuhan));
+    const getBeijingWeather = get(server.url(beijing));
+    const getWuhanWeather = get(server.url(wuhan));
 
     return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
       // since these are parallel, we have an unexpected order

--- a/packages/zipkin-instrumentation-superagent/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-superagent/test/integrationTest.js
@@ -5,10 +5,10 @@ import zipkinPlugin from '../src/superagentPlugin';
 const {expect} = require('chai');
 const {ExplicitContext, Tracer} = require('zipkin');
 const {
-  maybeMiddleware,
-  newSpanRecorder,
   expectB3Headers,
-  expectSpan
+  expectSpan,
+  newSpanRecorder,
+  setupTestServer
 } = require('../../../test/testFixture');
 
 // NOTE: axiosjs raises an error on non 2xx status instead of passing to the normal callback.
@@ -16,24 +16,7 @@ describe('SuperAgent instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let server;
-  let baseURL = ''; // default to relative path, for browser-based tests
-
-  before((done) => {
-    const middleware = maybeMiddleware();
-    if (middleware !== null) {
-      server = middleware.listen(0, () => {
-        baseURL = `http://127.0.0.1:${server.address().port}`;
-        done();
-      });
-    } else { // Inside a browser
-      done();
-    }
-  });
-
-  after(() => {
-    if (server) server.close();
-  });
+  setupTestServer();
 
   let spans;
   let tracer;
@@ -57,7 +40,7 @@ describe('SuperAgent instrumentation - integration test', () => {
   }
 
   function url(path) {
-    return `${baseURL}${path}?index=10&count=300`;
+    return `${global.baseURL}${path}?index=10&count=300`;
   }
 
   function successSpan(path) {

--- a/test/testFixture.js
+++ b/test/testFixture.js
@@ -14,8 +14,13 @@ function maybeMiddleware() {
   return middleware();
 }
 
-// Sets up a test server appropriate for either normal mocha or browser-based tests
-// exposes ${global.baseURL} for use in client tests.
+// Sets up a test server appropriate for either normal mocha or browser-based tests.
+//
+// Installation should be like this
+//
+// const server = setupTestServer();
+//
+// Later, you can get a url for clients to use via server.url(path)
 //
 // Approach is from https://github.com/mochajs/mocha/wiki/Shared-Behaviours
 function setupTestServer() {

--- a/test/testFixture.js
+++ b/test/testFixture.js
@@ -1,10 +1,12 @@
+function inBrowser() {
+  return typeof window !== 'undefined' && typeof window.__karma__ !== 'undefined';
+}
+
 // Returns test endpoint middleware or null if in a browser. If in a browser, use relative urls.
 function maybeMiddleware() {
   // First, check if we are running tests inside the web browser. If so, we expect Karma's server
   // host the endpoints we need. This means we use a relative instead of an absolute URL in tests.
-  if (typeof window !== 'undefined' && typeof window.__karma__ !== 'undefined') {
-    return null;
-  }
+  if (inBrowser()) return null;
 
   // Intentionally defer express middleware to avoid attempts to bundle it when in a browser
   // eslint-disable-next-line global-require
@@ -33,6 +35,12 @@ function setupTestServer() {
   after(() => {
     if (this.server) this.server.close();
   });
+
+  return { // these use global references as we are leaving 'this'
+    url(path) {
+      return `${global.baseURL}${path}?index=10&count=300`;
+    }
+  };
 };
 
 // This will make a span recorder that adds to the passed array exactly as they would appear in json
@@ -80,4 +88,4 @@ function expectSpan(span, expected) {
   expect(span).to.deep.equal({...volatileProperties, ...expected});
 }
 
-module.exports = {setupTestServer, newSpanRecorder, expectB3Headers, expectSpan}
+module.exports = {inBrowser, setupTestServer, newSpanRecorder, expectB3Headers, expectSpan}


### PR DESCRIPTION
This starts to pare down test duplication by extracting out a facet that
manages the start and stop of middleware used in client integration
tests.

Installation should be like this
```javascript
const {setupTestServer} = require('../../../test/testFixture');

const server = setupTestServer();
```

Later, you can get a url for clients to use via `server.url(path)`

See https://github.com/mochajs/mocha/wiki/Shared-Behaviours