### PR TITLE
Extracts a tracer fixture to remove copy/paste and fixes scoping problems in instrumentation

### DIFF
--- a/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
+++ b/packages/zipkin-instrumentation-express/src/wrapExpressHttpProxy.js
@@ -13,16 +13,15 @@ class ExpressHttpProxyInstrumentation {
     this.remoteServiceName = remoteServiceName;
   }
 
-  decorateAndRecordRequest(proxyReq, originalReq) {
-    return this.tracer.scoped(() => {
-      this.tracer.setId(this.tracer.createChildId());
-      const traceId = this.tracer.id;
+  decorateAndRecordRequest(serverReq, proxyReq, serverTraceId) {
+    return this.tracer.letId(serverTraceId, () => {
+      const clientTraceId = this.tracer.createChildId();
+      this.tracer.setId(clientTraceId);
 
-      // for use later when recording response
-      const originalReqWithTrace = originalReq;
-      originalReqWithTrace.traceId = traceId;
+      const proxyReqWithZipkinHeaders = Request.addZipkinHeaders(proxyReq, clientTraceId);
+      Object.defineProperty(serverReq, '_trace_id_proxy',
+        {configurable: false, get: () => clientTraceId});
 
-      const proxyReqWithZipkinHeaders = Request.addZipkinHeaders(proxyReq, traceId);
       this._recordRequest(proxyReqWithZipkinHeaders);
       return proxyReqWithZipkinHeaders;
     });
@@ -41,9 +40,8 @@ class ExpressHttpProxyInstrumentation {
     }
   }
 
-  recordResponse(rsp, originalReq) {
-    this.tracer.scoped(() => {
-      this.tracer.setId(originalReq.traceId);
+  recordResponse(rsp, clientTraceId) {
+    this.tracer.letId(clientTraceId, () => {
       this.tracer.recordBinary('http.status_code', rsp.statusCode.toString());
       this.tracer.recordAnnotation(new Annotation.ClientRecv());
     });
@@ -52,27 +50,31 @@ class ExpressHttpProxyInstrumentation {
 
 function wrapProxy(proxy, {tracer, serviceName, remoteServiceName}) {
   return function zipkinProxy(host, options = {}) {
-    function wrapDecorateRequest(instrumentation, originalDecorateRequest) {
-      return (proxyReq, originalReq) => {
+    function wrapDecorateRequest(instrumentation, decorateFunction) {
+      return (proxyReq, serverReq) => {
+        const serverTraceId = serverReq._trace_id;
         let wrappedProxyReq = proxyReq;
-
-        if (typeof originalDecorateRequest === 'function') {
-          wrappedProxyReq = originalDecorateRequest(proxyReq, originalReq);
+        if (typeof decorateFunction === 'function') {
+          tracer.letId(serverTraceId, () => {
+            wrappedProxyReq = decorateFunction(proxyReq, serverReq);
+          });
         }
 
-        return instrumentation.decorateAndRecordRequest(wrappedProxyReq, originalReq);
+        return instrumentation.decorateAndRecordRequest(serverReq, wrappedProxyReq, serverTraceId);
       };
     }
 
-    function wrapIntercept(instrumentation, originalIntercept) {
-      return (rsp, data, originalReq, res, callback) => {
+    function wrapIntercept(instrumentation, interceptFunction) {
+      return (rsp, data, serverReq, res, callback) => {
         const instrumentedCallback = (err, rspd, sent) => {
-          instrumentation.recordResponse(rsp, originalReq);
+          instrumentation.recordResponse(rsp, serverReq._trace_id_proxy);
           return callback(err, rspd, sent);
         };
 
-        if (typeof originalIntercept === 'function') {
-          originalIntercept(rsp, data, originalReq, res, instrumentedCallback);
+        const serverTraceId = serverReq._trace_id;
+        if (typeof interceptFunction === 'function') {
+          tracer.letId(serverTraceId,
+            () => interceptFunction(rsp, data, serverReq, res, instrumentedCallback));
         } else {
           instrumentedCallback(null, data);
         }
@@ -85,11 +87,11 @@ function wrapProxy(proxy, {tracer, serviceName, remoteServiceName}) {
 
     const wrappedOptions = options;
 
-    const originalDecorateRequest = wrappedOptions.decorateRequest;
-    wrappedOptions.decorateRequest = wrapDecorateRequest(instrumentation, originalDecorateRequest);
+    const serverReq = wrappedOptions.decorateRequest;
+    wrappedOptions.decorateRequest = wrapDecorateRequest(instrumentation, serverReq);
 
-    const originalIntercept = wrappedOptions.intercept;
-    wrappedOptions.intercept = wrapIntercept(instrumentation, originalIntercept);
+    const serverIntercept = wrappedOptions.intercept;
+    wrappedOptions.intercept = wrapIntercept(instrumentation, serverIntercept);
 
     return proxy(host, wrappedOptions);
   };

--- a/packages/zipkin-instrumentation-express/test/testMiddleware.js
+++ b/packages/zipkin-instrumentation-express/test/testMiddleware.js
@@ -1,7 +1,9 @@
-function step(tracer, num) {
+// Until there is a CLS hooked implementation here, we need to be explicit with trace IDs.
+// See https://github.com/openzipkin/zipkin-js/issues/88
+function step(tracer, req, num) {
   return new Promise((done) => {
     setTimeout(() => {
-      tracer.scoped(() => {
+      tracer.letId(req._trace_id, () => {
         tracer.recordBinary('step', num.toString());
         done();
       });
@@ -11,24 +13,24 @@ function step(tracer, num) {
 
 function addTestRoutes(app, tracer) {
   app.get('/weather/wuhan', (req, res) => {
-    tracer.recordBinary('city', 'wuhan');
+    if (tracer) tracer.recordBinary('city', 'wuhan');
     res.status(200).json(req.headers);
   });
   app.get('/weather/beijing', (req, res) => {
-    tracer.recordBinary('city', 'beijing');
+    if (tracer) tracer.recordBinary('city', 'beijing');
     res.status(200).json(req.headers);
   });
   app.get('/weather/securedTown', (req, res) => {
-    tracer.recordBinary('city', 'securedTown');
+    if (tracer) tracer.recordBinary('city', 'securedTown');
     res.status(401).json(req.headers);
   });
   app.get('/weather/bagCity', (req, res, next) => {
-    tracer.recordBinary('city', 'bagCity');
+    if (tracer) tracer.recordBinary('city', 'bagCity');
     next(new Error('service is dead'));
   });
-  app.get('/steps', (req, res) => step(tracer, 1)
-    .then(() => step(tracer, 2))
-    .then(() => step(tracer, 3))
+  app.get('/steps', (req, res) => step(tracer, req, 1)
+    .then(() => step(tracer, req, 2))
+    .then(() => step(tracer, req, 3))
     .then(() => res.status(200).json(req.headers)));
   return app;
 }

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -3,12 +3,7 @@ import tracingInterceptor from '../src/grpcClientInterceptor';
 
 import {mockServer, weather} from './utils';
 
-const {ExplicitContext, Tracer} = require('zipkin');
-const {
-  newSpanRecorder,
-  expectB3Headers,
-  expectSpan
-} = require('../../../test/testFixture');
+const {expectB3Headers, setupTestTracer} = require('../../../test/testFixture');
 
 describe('gRPC client instrumentation (integration test)', () => {
   const serviceName = 'weather-app';
@@ -25,25 +20,7 @@ describe('gRPC client instrumentation (integration test)', () => {
 
   after(() => server.forceShutdown());
 
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      localServiceName: serviceName,
-      ctxImpl: new ExplicitContext(),
-      recorder: newSpanRecorder(spans)
-    });
-  });
-
-  // TODO: pull into http tests also
-  afterEach(() => expect(spans).to.be.empty);
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   function successSpan(name) {
     return ({
@@ -56,7 +33,7 @@ describe('gRPC client instrumentation (integration test)', () => {
   }
 
   function getClient(host = 'localhost:50051') {
-    const interceptor = tracingInterceptor(grpc, {tracer, remoteServiceName});
+    const interceptor = tracingInterceptor(grpc, {tracer: tracer.tracer(), remoteServiceName});
     return new weather.WeatherService(
       host,
       grpc.credentials.createInsecure(),
@@ -68,34 +45,30 @@ describe('gRPC client instrumentation (integration test)', () => {
     if (err) return done(err);
 
     const {metadata} = res;
-    expectB3Headers(popSpan(), metadata);
+    expectB3Headers(tracer.popSpan(), metadata);
     return done();
   }));
 
-  // TODO: this test needs to be pulled up also to the other clients
-  it('should send "x-b3-flags" header', (done) => {
-    // enables debug
-    tracer.setId(tracer.createRootId(undefined, true));
-
-    getClient().getTemperature({location: 'Tahoe'}, (err, res) => {
+  it('should send "x-b3-flags" header when debug', (done) => {
+    tracer.runInDebugTrace(() => getClient().getTemperature({location: 'Tahoe'}, (err, res) => {
       if (err) return done(err);
 
       const {metadata} = res;
-      expectB3Headers(popSpan(), metadata);
+      expectB3Headers(tracer.popDebugSpan(), metadata);
       return done();
-    });
+    }));
   });
 
   it('should record successful request', done => getClient().getTemperature({location: 'Tahoe'}, (err) => {
     if (err) return done(err);
 
-    expectSpan(popSpan(), successSpan(temperature));
+    tracer.popSpanAndExpect(successSpan(temperature));
     return done();
   }));
 
   it('should report error in tags', done => getClient().getTemperature({location: 'Las Vegas'}, (err, res) => {
     if (err) {
-      expectSpan(popSpan(), {
+      tracer.popSpanAndExpect({
         name: temperature,
         kind: 'CLIENT',
         localEndpoint: {serviceName},
@@ -113,7 +86,7 @@ describe('gRPC client instrumentation (integration test)', () => {
 
   it('should report error in tags on transport error', done => getClient('localhost:12345').getTemperature({location: 'Las Vegas'}, (err, res) => {
     if (err) {
-      expectSpan(popSpan(), {
+      tracer.popSpanAndExpect({
         name: temperature,
         kind: 'CLIENT',
         localEndpoint: {serviceName},
@@ -140,8 +113,8 @@ describe('gRPC client instrumentation (integration test)', () => {
           if (err2) done(err2);
 
           // since these are sequential, we should have an expected order
-          expectSpan(popSpan(), successSpan(locations));
-          expectSpan(popSpan(), successSpan(temperature));
+          tracer.popSpanAndExpect(successSpan(locations));
+          tracer.popSpanAndExpect(successSpan(temperature));
           done();
         });
       }
@@ -160,12 +133,12 @@ describe('gRPC client instrumentation (integration test)', () => {
 
     return Promise.all([getTemperature, getLocations]).then(() => {
       // since these are parallel, we have an unexpected order
-      const firstSpan = popSpan(); // TODO: move this race condition fix to http
+      const firstSpan = tracer.popSpan();
       const firstName = firstSpan.name === temperature ? temperature : locations;
       const secondName = firstName === temperature ? locations : temperature;
 
-      expectSpan(firstSpan, successSpan(firstName));
-      expectSpan(popSpan(), successSpan(secondName));
+      tracer.expectSpan(firstSpan, successSpan(firstName));
+      tracer.popSpanAndExpect(successSpan(secondName));
     });
   });
 });

--- a/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-grpc-client/test/integrationTest.js
@@ -1,8 +1,7 @@
-import grpc from 'grpc';
-import tracingInterceptor from '../src/grpcClientInterceptor';
+const grpc = require('grpc');
+const tracingInterceptor = require('../src/grpcClientInterceptor');
 
-import {mockServer, weather} from './utils';
-
+const {mockServer, weather} = require('./utils');
 const {expectB3Headers, setupTestTracer} = require('../../../test/testFixture');
 
 describe('gRPC client instrumentation (integration test)', () => {
@@ -62,13 +61,13 @@ describe('gRPC client instrumentation (integration test)', () => {
   it('should record successful request', done => getClient().getTemperature({location: 'Tahoe'}, (err) => {
     if (err) return done(err);
 
-    tracer.popSpanAndExpect(successSpan(temperature));
+    tracer.expectNextSpanToEqual(successSpan(temperature));
     return done();
   }));
 
   it('should report error in tags', done => getClient().getTemperature({location: 'Las Vegas'}, (err, res) => {
     if (err) {
-      tracer.popSpanAndExpect({
+      tracer.expectNextSpanToEqual({
         name: temperature,
         kind: 'CLIENT',
         localEndpoint: {serviceName},
@@ -86,7 +85,7 @@ describe('gRPC client instrumentation (integration test)', () => {
 
   it('should report error in tags on transport error', done => getClient('localhost:12345').getTemperature({location: 'Las Vegas'}, (err, res) => {
     if (err) {
-      tracer.popSpanAndExpect({
+      tracer.expectNextSpanToEqual({
         name: temperature,
         kind: 'CLIENT',
         localEndpoint: {serviceName},
@@ -113,8 +112,8 @@ describe('gRPC client instrumentation (integration test)', () => {
           if (err2) done(err2);
 
           // since these are sequential, we should have an expected order
-          tracer.popSpanAndExpect(successSpan(locations));
-          tracer.popSpanAndExpect(successSpan(temperature));
+          tracer.expectNextSpanToEqual(successSpan(locations));
+          tracer.expectNextSpanToEqual(successSpan(temperature));
           done();
         });
       }
@@ -138,7 +137,7 @@ describe('gRPC client instrumentation (integration test)', () => {
       const secondName = firstName === temperature ? locations : temperature;
 
       tracer.expectSpan(firstSpan, successSpan(firstName));
-      tracer.popSpanAndExpect(successSpan(secondName));
+      tracer.expectNextSpanToEqual(successSpan(secondName));
     });
   });
 });

--- a/packages/zipkin-instrumentation-memcached/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-memcached/test/integrationTest.js
@@ -1,8 +1,7 @@
-const {ExplicitContext, Tracer} = require('zipkin');
 const Memcached = require('memcached');
-const {newSpanRecorder, expectSpan} = require('../../../test/testFixture');
-
 const zipkinClient = require('../src/zipkinClient');
+
+const {setupTestTracer} = require('../../../test/testFixture');
 
 // This instrumentation records metadata, but does not affect memcached requests otherwise. Hence,
 // these tests do not expect B3 headers.
@@ -10,25 +9,7 @@ describe('memcached instrumentation (integration test)', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      localServiceName: serviceName,
-      ctxImpl: new ExplicitContext(),
-      recorder: newSpanRecorder(spans)
-    });
-  });
-
-  // TODO: pull into http tests also
-  afterEach(() => expect(spans).to.be.empty);
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   function clientSpan(name, tags) {
     return ({
@@ -41,7 +22,7 @@ describe('memcached instrumentation (integration test)', () => {
   }
 
   function getClient(host = process.env.MEMCACHED_HOST || 'localhost:11211') {
-    return new (zipkinClient(tracer, Memcached, serviceName, remoteServiceName))(host, {
+    return new (zipkinClient(tracer.tracer(), Memcached, serviceName, remoteServiceName))(host, {
       timeout: 1000,
       idle: 1000,
       failures: 0,
@@ -53,50 +34,34 @@ describe('memcached instrumentation (integration test)', () => {
   it('should record successful request', done => getClient().set('ping', 'pong', 10, (err) => {
     if (err) return done(err);
 
-    expectSpan(popSpan(), clientSpan('set', {'memcached.key': 'ping'}));
+    tracer.expectNextSpanToEqual(clientSpan('set', {'memcached.key': 'ping'}));
     return done();
   }));
 
-  it('should report error in tags on transport error', done => getClient('localhost:12345').set('scooby', 'doo', 10, (err, data) => {
-    if (!err) return done(new Error(`expected response to error: ${data}`));
+  it('should report error in tags on transport error', done => getClient('localhost:12345')
+    .set('scooby', 'doo', 10, (err, data) => {
+      if (!err) return done(new Error(`expected response to error: ${data}`));
 
-    expectSpan(popSpan(), clientSpan('set', {
-      'memcached.key': 'scooby',
-      error: 'connect ECONNREFUSED 127.0.0.1:12345'
+      tracer.expectNextSpanToEqual(clientSpan('set', {
+        'memcached.key': 'scooby',
+        error: 'connect ECONNREFUSED 127.0.0.1:12345'
+      }));
+      return done();
     }));
-    return done();
-  }));
 
   it('should handle nested requests', (done) => {
     const memcached = getClient();
     memcached.set('foo', 'bar', 10, (err) => {
       if (err) return done(err);
 
-      expectSpan(popSpan(), clientSpan('set', {'memcached.key': 'foo'}));
+      tracer.expectNextSpanToEqual(clientSpan('set', {'memcached.key': 'foo'}));
       return memcached.getMulti(['foo', 'fox'], (err2, data) => {
         if (err2) return done(err2);
 
         expect(data).to.deep.equal({foo: 'bar'});
-        expectSpan(popSpan(), clientSpan('get-multi', {'memcached.keys': 'foo,fox'}));
+        tracer.expectNextSpanToEqual(clientSpan('get-multi', {'memcached.keys': 'foo,fox'}));
         return done();
       });
-    });
-  });
-
-  // TODO: add to all client tests
-  it('should restore original trace ID', (done) => {
-    const rootId = tracer.createRootId();
-    tracer.setId(rootId);
-
-    getClient().set('scooby', 'doo', 10, (err) => {
-      if (err) return done(err);
-
-      // the recorded span is a child of the original
-      expect(tracer.id.spanId).to.equal(popSpan().parentId);
-
-      // the original span ID is now current
-      expect(tracer.id.traceId).to.equal(rootId.traceId);
-      return done();
     });
   });
 });

--- a/packages/zipkin-instrumentation-redis/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-redis/test/integrationTest.js
@@ -1,8 +1,7 @@
-const {ExplicitContext, Tracer} = require('zipkin');
 const redis = require('redis');
-const {newSpanRecorder, expectSpan} = require('../../../test/testFixture');
-
 const zipkinClient = require('../src/zipkinClient');
+
+const {setupTestTracer} = require('../../../test/testFixture');
 
 // This instrumentation records metadata, but does not affect redis requests otherwise. Hence,
 // these tests do not expect B3 headers.
@@ -10,25 +9,7 @@ describe('redis instrumentation (integration test)', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      localServiceName: serviceName,
-      ctxImpl: new ExplicitContext(),
-      recorder: newSpanRecorder(spans)
-    });
-  });
-
-  // TODO: pull into http tests also
-  afterEach(() => expect(spans).to.be.empty);
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   function clientSpan(name, tags) {
     const result = {
@@ -46,7 +27,7 @@ describe('redis instrumentation (integration test)', () => {
 
   function getClient(done, options = {expectSuccess: true}) {
     const host = options.host || 'localhost:6379';
-    const result = zipkinClient(tracer, redis, {
+    const result = zipkinClient(tracer.tracer(), redis, {
       host: host.split(':')[0],
       port: host.split(':')[1],
     }, serviceName, remoteServiceName);
@@ -55,52 +36,39 @@ describe('redis instrumentation (integration test)', () => {
   }
 
   it('should record successful request', done => getClient(done).set('ping', 'pong', () => {
-    expectSpan(popSpan(), clientSpan('set'));
+    tracer.expectNextSpanToEqual(clientSpan('set'));
     done();
   }));
 
-  it('should record successful batch request', done => getClient(done).batch([['get', 'ping'], ['set', 'syn', 'ack']]).exec(() => {
-    // TODO: should this span be named exec?
-    expectSpan(popSpan(), clientSpan('exec', {commands: '["get","set"]'}));
-    done();
-  }));
-
-  it('should report error in tags', done => getClient(done, {expectSuccess: false}).get('ping', 'pong', (err, data) => {
-    if (!err) {
-      done(new Error(`expected response to error: ${data}`));
-    } else {
-      expectSpan(popSpan(), clientSpan('get', {
-        error: 'ERR wrong number of arguments for \'get\' command'
-      }));
+  it('should record successful batch request', done => getClient(done)
+    .batch([['get', 'ping'], ['set', 'syn', 'ack']]).exec(() => {
+      // TODO: should this span be named exec?
+      tracer.expectNextSpanToEqual(clientSpan('exec', {commands: '["get","set"]'}));
       done();
-    }
-  }));
+    }));
+
+  it('should report error in tags', done => getClient(done, {expectSuccess: false})
+    .get('ping', 'pong', (err, data) => {
+      if (!err) {
+        done(new Error(`expected response to error: ${data}`));
+      } else {
+        tracer.expectNextSpanToEqual(clientSpan('get', {
+          error: 'ERR wrong number of arguments for \'get\' command'
+        }));
+        done();
+      }
+    }));
 
   it('should handle nested requests', (done) => {
     const client = getClient(done);
     client.set('foo', 'bar', () => {
-      expectSpan(popSpan(), clientSpan('set'));
+      tracer.expectNextSpanToEqual(clientSpan('set'));
 
       client.get('foo', (err, data) => {
-        expectSpan(popSpan(), clientSpan('get'));
+        tracer.expectNextSpanToEqual(clientSpan('get'));
         expect(data).to.deep.equal('bar');
         done();
       });
-    });
-  });
-
-  // TODO: add to all client tests
-  it('should restore original trace ID', (done) => {
-    const rootId = tracer.createRootId();
-    tracer.setId(rootId);
-
-    getClient(done).set('scooby', 'doo', () => {
-      // the recorded span is a child of the original
-      expect(tracer.id.spanId).to.equal(popSpan().parentId);
-
-      // the original span ID is now current
-      expect(tracer.id.traceId).to.equal(rootId.traceId);
-      done();
     });
   });
 });

--- a/packages/zipkin-instrumentation-request-promise/src/request.js
+++ b/packages/zipkin-instrumentation-request-promise/src/request.js
@@ -32,13 +32,13 @@ const Request = class {
       const wrappedOptions = this.instrumentation.recordRequest(options, url, method);
       const traceId = tracer.id;
 
-      const recordResponse = (response) => {
-        this.instrumentation.recordResponse(traceId, response.statusCode);
-      };
+      const recordResponse = response => tracer.scoped( // TODO: scoped bc recordResponse leaks
+        () => this.instrumentation.recordResponse(traceId, response.statusCode)
+      );
 
-      const recordError = (error) => {
-        this.instrumentation.recordError(traceId, error);
-      };
+      const recordError = error => tracer.scoped( // TODO: scoped bc recordError leaks
+        () => this.instrumentation.recordError(traceId, error)
+      );
 
       return request(wrappedOptions, callback)
         .on('response', recordResponse)

--- a/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
@@ -1,11 +1,4 @@
-const {expect} = require('chai');
-const {ExplicitContext, Tracer} = require('zipkin');
-const {
-  expectB3Headers,
-  expectSpan,
-  newSpanRecorder,
-  setupTestServer
-} = require('../../../test/testFixture');
+const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
 
 const ZipkinRequest = require('../src/request').default;
 
@@ -15,27 +8,11 @@ describe('request-promise instrumentation - integration test', () => {
   const remoteServiceName = 'weather-api';
 
   const server = setupTestServer();
-
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      ctxImpl: new ExplicitContext(),
-      localServiceName: serviceName,
-      recorder: newSpanRecorder(spans)
-    });
-  });
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   function getClient() {
     // NOTE: this is instantiated differently than others: you don't pass in a request function
-    return new ZipkinRequest(tracer, remoteServiceName);
+    return new ZipkinRequest(tracer.tracer(), remoteServiceName);
   }
 
   function successSpan(path) {
@@ -54,13 +31,20 @@ describe('request-promise instrumentation - integration test', () => {
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
     return getClient().get(server.url(path))
-      .then(response => expectB3Headers(popSpan(), JSON.parse(response)));
+      .then(response => expectB3Headers(tracer.popSpan(), JSON.parse(response)));
+  });
+
+  // TODO: move to other http tests
+  it('should send "x-b3-flags" header when debug', () => {
+    const path = '/weather/wuhan';
+    return tracer.runInDebugTrace(() => getClient().get(server.url(path))
+      .then(response => expectB3Headers(tracer.popDebugSpan(), JSON.parse(response))));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
     return getClient().get(server.url(path))
-      .then(() => expectSpan(popSpan(), successSpan(path)));
+      .then(() => tracer.popSpanAndExpect(successSpan(path)));
   });
 
   it('should report 404 in tags', (done) => {
@@ -70,7 +54,7 @@ describe('request-promise instrumentation - integration test', () => {
         done(new Error(`expected status 404 response to error. status: ${response.status}`));
       })
       .catch(() => {
-        expectSpan(popSpan(), {
+        tracer.popSpanAndExpect({
           name: 'get',
           kind: 'CLIENT',
           localEndpoint: {serviceName},
@@ -92,7 +76,7 @@ describe('request-promise instrumentation - integration test', () => {
         done(new Error(`expected status 401 response to error. status: ${response.status}`));
       })
       .catch(() => {
-        expectSpan(popSpan(), {
+        tracer.popSpanAndExpect({
           name: 'get',
           kind: 'CLIENT',
           localEndpoint: {serviceName},
@@ -114,7 +98,7 @@ describe('request-promise instrumentation - integration test', () => {
         done(new Error(`expected status 500 response to error. status: ${response.status}`));
       })
       .catch(() => {
-        expectSpan(popSpan(), {
+        tracer.popSpanAndExpect({
           name: 'get',
           kind: 'CLIENT',
           localEndpoint: {serviceName},
@@ -139,7 +123,7 @@ describe('request-promise instrumentation - integration test', () => {
         done(new Error(`expected an invalid host to error. status: ${response.status}`));
       })
       .catch((error) => {
-        expectSpan(popSpan(), {
+        tracer.popSpanAndExpect({
           name: 'get',
           kind: 'CLIENT',
           localEndpoint: {serviceName},
@@ -162,15 +146,14 @@ describe('request-promise instrumentation - integration test', () => {
     const getBeijingWeather = client.get(server.url(beijing));
     const getWuhanWeather = client.get(server.url(wuhan));
 
-    return getBeijingWeather.then(() => {
-      getWuhanWeather.then(() => {
-        // since these are sequential, we should have an expected order
-        expectSpan(popSpan(), successSpan(wuhan));
-        expectSpan(popSpan(), successSpan(beijing));
-      });
-    });
+    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
+      // since these are sequential, we should have an expected order
+      tracer.popSpanAndExpect(successSpan(wuhan));
+      tracer.popSpanAndExpect(successSpan(beijing));
+    }));
   });
 
+  // TODO: not all http clients test this
   it('should support parallel get requests', () => {
     const client = getClient();
 
@@ -181,11 +164,12 @@ describe('request-promise instrumentation - integration test', () => {
     const getWuhanWeather = client.get(server.url(wuhan));
 
     return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstPath = spans[0].tags['http.path'] === wuhan ? beijing : wuhan;
+      const firstSpan = tracer.popSpan();
+      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
       const secondPath = firstPath === wuhan ? beijing : wuhan;
-      expectSpan(popSpan(), successSpan(firstPath));
-      expectSpan(popSpan(), successSpan(secondPath));
+
+      tracer.expectSpan(firstSpan, successSpan(firstPath));
+      tracer.popSpanAndExpect(successSpan(secondPath));
     });
   });
 });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -1,40 +1,17 @@
-const {expect} = require('chai');
-const {ExplicitContext, Tracer} = require('zipkin');
-
 const request = require('request');
-const {
-  expectB3Headers,
-  expectSpan,
-  newSpanRecorder,
-  setupTestServer
-} = require('../../../test/testFixture');
 const wrapRequest = require('../src/index');
+
+const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
 
 describe('request instrumentation - integration test', () => {
   const serviceName = 'weather-app';
   const remoteServiceName = 'weather-api';
 
   const server = setupTestServer();
-
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      ctxImpl: new ExplicitContext(),
-      localServiceName: serviceName,
-      recorder: newSpanRecorder(spans)
-    });
-  });
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   function getClient() {
-    return wrapRequest(request, {tracer, remoteServiceName});
+    return wrapRequest(request, {tracer: tracer.tracer(), remoteServiceName});
   }
 
   function successSpan(path) {
@@ -52,78 +29,62 @@ describe('request instrumentation - integration test', () => {
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';
-    return getClient().get(server.url(path))
-      .on('body', body => expectB3Headers(popSpan(), body));
+    getClient().get(server.url(path)).on('body', body => expectB3Headers(tracer.popSpan(), body));
   });
 
   it('should support get request', () => {
     const path = '/weather/wuhan';
-    return getClient().get(server.url(path), () => expectSpan(popSpan(), successSpan(path)));
+    getClient().get(server.url(path), () => tracer.expectNextSpanToEqual(successSpan(path)));
   });
 
   it('should support options request', () => {
     const path = '/weather/wuhan';
-    return getClient()({url: server.url(path)}, () => expectSpan(popSpan(), successSpan(path)));
+    getClient()({url: server.url(path)}, () => tracer.expectNextSpanToEqual(successSpan(path)));
   });
 
-  it('should report 404 in tags', (done) => {
+  it('should report 404 in tags', () => {
     const path = '/pathno';
-    getClient().get(server.url(path))
-      .on('response', () => {
-        expectSpan(popSpan(), {
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '404',
-            error: '404'
-          }
-        });
-        done();
-      })
-      .on('error', error => done(error));
+    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
+      name: 'get',
+      kind: 'CLIENT',
+      localEndpoint: {serviceName},
+      remoteEndpoint: {serviceName: remoteServiceName},
+      tags: {
+        'http.path': path,
+        'http.status_code': '404',
+        error: '404'
+      }
+    }));
   });
 
-  it('should report 401 in tags', (done) => {
+  it('should report 401 in tags', () => {
     const path = '/weather/securedTown';
-    getClient().get(server.url(path))
-      .on('response', () => {
-        expectSpan(popSpan(), {
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '401',
-            error: '401'
-          }
-        });
-        done();
-      })
-      .on('error', error => done(error));
+    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
+      name: 'get',
+      kind: 'CLIENT',
+      localEndpoint: {serviceName},
+      remoteEndpoint: {serviceName: remoteServiceName},
+      tags: {
+        'http.path': path,
+        'http.status_code': '401',
+        error: '401'
+      }
+    }));
   });
 
-  it('should report 500 in tags', (done) => {
+  it('should report 500 in tags', () => {
     const path = '/weather/bagCity';
-    getClient().get(server.url(path))
-      .on('response', () => {
-        expectSpan(popSpan(), {
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '500',
-            error: '500'
-          }
-        });
-        done();
-      })
-      .on('error', error => done(error));
+    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
+      name: 'get',
+      kind: 'CLIENT',
+      localEndpoint: {serviceName},
+      remoteEndpoint: {serviceName: remoteServiceName},
+      tags: {
+        'http.path': path,
+        'http.status_code': '500',
+        error: '500'
+      }
+    }));
   });
 
   it('should report when endpoint doesnt exist in tags', (done) => {
@@ -131,7 +92,7 @@ describe('request instrumentation - integration test', () => {
     const badUrl = `http://localhost:12345${path}`;
     getClient().get({url: badUrl, timeout: 300})
       .on('error', (error) => {
-        expectSpan(popSpan(), {
+        tracer.expectNextSpanToEqual({
           name: 'get',
           kind: 'CLIENT',
           localEndpoint: {serviceName},
@@ -153,9 +114,9 @@ describe('request instrumentation - integration test', () => {
     const wuhan = '/weather/wuhan';
 
     client.get(server.url(beijing), () => client.get(server.url(wuhan), () => {
-      // since these are sequential, we should have an expected order
-      expectSpan(popSpan(), successSpan(wuhan));
-      expectSpan(popSpan(), successSpan(beijing));
+      // since these are blocking requests, we should have an expected order
+      tracer.expectNextSpanToEqual(successSpan(wuhan));
+      tracer.expectNextSpanToEqual(successSpan(beijing));
     }));
   });
 });

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -1,50 +1,47 @@
 const {expect} = require('chai');
-const {ExplicitContext, InetAddress, Tracer} = require('zipkin');
-
+const {InetAddress} = require('zipkin');
 const fetch = require('node-fetch');
+
 const restify = require('restify');
 const middleware = require('../src/restifyMiddleware');
-const {newSpanRecorder, expectSpan} = require('../../../test/testFixture');
+
+const {setupTestTracer} = require('../../../test/testFixture');
 
 describe('restify instrumentation - integration test', () => {
   const serviceName = 'weather-api';
   const ipv4 = InetAddress.getLocalAddress().ipv4();
 
-  let spans;
-  let tracer;
-
-  beforeEach(() => {
-    spans = [];
-    tracer = new Tracer({
-      localServiceName: serviceName,
-      ctxImpl: new ExplicitContext(),
-      recorder: newSpanRecorder(spans)
-    });
-  });
+  const tracer = setupTestTracer({localServiceName: serviceName});
 
   let server;
   let baseURL;
 
+  // Restify uses async hooks. Until there is a CLS hooked implementation here, we need to be
+  // explicit with trace IDs. See https://github.com/openzipkin/zipkin-js/issues/88
+  function addTag(req, key, value) {
+    tracer.tracer().letId(req._trace_id, () => tracer.tracer().recordBinary(key, value));
+  }
+
   beforeEach((done) => {
     const app = restify.createServer({handleUncaughtExceptions: true});
-    app.use(middleware({tracer}));
+    app.use(middleware({tracer: tracer.tracer()}));
     app.get('/weather/wuhan', (req, res, next) => {
-      tracer.recordBinary('city', 'wuhan');
+      addTag(req, 'city', 'wuhan');
       res.send(200, req.headers);
       return next();
     });
     app.get('/weather/beijing', (req, res, next) => {
-      tracer.recordBinary('city', 'beijing');
+      addTag(req, 'city', 'beijing');
       res.send(200, req.headers);
       return next();
     });
     app.get('/weather/securedTown', (req, res, next) => {
-      tracer.recordBinary('city', 'securedTown');
+      addTag(req, 'city', 'securedTown');
       res.send(401, req.headers);
       return next();
     });
-    app.get('/weather/bagCity', () => {
-      tracer.recordBinary('city', 'bagCity');
+    app.get('/weather/bagCity', (req) => {
+      addTag(req, 'city', 'bagCity');
       throw new Error('service is dead');
     });
     server = app.listen(0, () => {
@@ -55,13 +52,7 @@ describe('restify instrumentation - integration test', () => {
 
   afterEach(() => {
     if (server) server.close();
-    expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
-
-  function popSpan() {
-    expect(spans).to.not.be.empty; // eslint-disable-line no-unused-expressions
-    return spans.pop();
-  }
 
   function successSpan(path, city) {
     return ({
@@ -92,14 +83,13 @@ describe('restify instrumentation - integration test', () => {
 
   it('should start a new trace', () => {
     const path = '/weather/wuhan';
-    const url = `${baseURL}${path}`;
-    return fetch(url).then(() => expectSpan(popSpan(), successSpan(path, 'wuhan')));
+    fetch(`${baseURL}${path}`).then(() => tracer.expectNextSpanToEqual(successSpan(path, 'wuhan')));
   });
 
   it('http.path tag should not include query parameters', () => {
     const path = '/weather/wuhan';
     const url = `${baseURL}${path}?index=10&count=300`;
-    return fetch(url).then(() => expect(popSpan().tags['http.path']).to.equal(path));
+    fetch(url).then(() => expect(tracer.popSpan().tags['http.path']).to.equal(path));
   });
 
   it('should receive continue a trace from the client', () => {
@@ -112,11 +102,11 @@ describe('restify instrumentation - integration test', () => {
         'X-B3-Flags': '1'
       }
     }).then(() => {
-      const span = popSpan();
+      const span = tracer.expectNextSpanToEqual(
+        {...successSpan(path, 'wuhan'), ...{debug: true, shared: true}}
+      );
       expect(span.traceId).to.equal('863ac35c9f6413ad');
       expect(span.id).to.equal('48485a3953bb6124');
-
-      expectSpan(span, {...successSpan(path, 'wuhan'), ...{debug: true, shared: true}});
     });
   });
 
@@ -130,18 +120,18 @@ describe('restify instrumentation - integration test', () => {
         'X-B3-SpanId': '48485a3953bb6124',
         'X-B3-Sampled': '1'
       }
-    }).then(() => expect(popSpan().traceId).to.equal(traceId));
+    }).then(() => expect(tracer.popSpan().traceId).to.equal(traceId));
   });
 
   it('should report 401 in tags', () => {
     const path = '/weather/securedTown';
     return fetch(`${baseURL}${path}`)
-      .then(() => expectSpan(popSpan(), errorSpan(path, 'securedTown', 401)));
+      .then(() => tracer.expectNextSpanToEqual(errorSpan(path, 'securedTown', 401)));
   });
 
   it('should report 500 in tags', () => {
     const path = '/weather/bagCity';
     return fetch(`${baseURL}${path}`)
-      .then(() => expectSpan(popSpan(), errorSpan(path, 'bagCity', 500)));
+      .then(() => tracer.expectNextSpanToEqual(errorSpan(path, 'bagCity', 500)));
   });
 });


### PR DESCRIPTION
This ports all the instrumentation packages. There is still some porting opportunities in the reporters and the base module itself. However, this is a good place to stop for a bit.