### PR TITLE
Creates common fixture for http client test

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -1,199 +1,32 @@
 const axios = require('axios');
 const wrapAxios = require('../src/index');
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
-// NOTE: axiosjs raises an error on non 2xx status instead of passing to the normal callback.
 describe('axios instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function getClient() {
+  function clientFunction({tracer, remoteServiceName}) {
     const instance = axios.create({
       timeout: 300 // this avoids flakes in CI
     });
 
-    return wrapAxios(instance, {tracer: tracer.tracer(), remoteServiceName});
-  }
-
-  function successSpan(path) {
+    const wrapped = wrapAxios(instance, {tracer, remoteServiceName});
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return wrapped(url).catch((error) => {
+          // Handle axiosjs throwing on non 2xx status instead of passing to the normal callback.
+          if (error.response && error.response.status) return error.response;
+          throw error;
+        });
+      },
+      getOptions(url) {
+        return wrapped({url});
+      },
+      getJson(url) {
+        return wrapped(url).then(response => response.data);
       }
     });
   }
 
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return getClient().get(server.url(path))
-      .then(response => expectB3Headers(tracer.popSpan(), response.data));
-  });
-
-  it('should not interfere with errors that precede a call', (done) => {
-    // Here we are passing a function instead of the value of it. This ensures our error callback
-    // doesn't make assumptions about a span in progress: there won't be if there was a config error
-    getClient()(server.url)
-      .then((response) => {
-        done(new Error(`expected an invalid url parameter to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        const {message} = error;
-        const expected = ['must be of type string', 'must be a string']; // messages can vary in CI
-        if (message.indexOf(expected[0]) !== -1 || message.indexOf(expected[1]) !== -1) {
-          done();
-        } else {
-          done(new Error(`expected error message to match [${expected.toString()}]: ${message}`));
-        }
-      });
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return getClient().get(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should support options request', () => {
-    const path = '/weather/wuhan';
-    return getClient()({url: server.url(path)})
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', (done) => {
-    const path = '/pathno';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 404 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '404',
-            error: '404'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 401 in tags', (done) => {
-    const path = '/weather/securedTown';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 401 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '401',
-            error: '401'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 500 in tags', (done) => {
-    const path = '/weather/bagCity';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 500 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '500',
-            error: '500'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report when endpoint doesnt exist in tags', (done) => {
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    getClient().get(badUrl)
-      .then((response) => {
-        done(new Error(`expected an invalid host to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.toString()
-          }
-        });
-        done();
-      });
-  });
-
-  it('should support nested get requests', () => {
-    const client = getClient();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client.get(server.url(beijing));
-    const getWuhanWeather = client.get(server.url(wuhan));
-
-    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
-      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
-      // This defensiveness prevents CI flakes.
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    }));
-  });
-
-  it('should support parallel get requests', () => {
-    const client = getClient();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client.get(server.url(beijing));
-    const getWuhanWeather = client.get(server.url(wuhan));
-
-    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    });
-  });
+  const testClient = clientFixture.setupHttpClientTests({clientFunction});
+  clientFixture.testOptionsArgument(testClient);
 });

--- a/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/src/restInterceptor.js
@@ -25,7 +25,11 @@ function request(req, {tracer, serviceName, remoteServiceName}) {
 
 function response(res, {tracer}) {
   tracer.scoped(() => {
-    this.instrumentation.recordResponse(this.traceId, res.status.code);
+    if (res.error) { // check error, not status because in chrome it is sometimes zero!
+      this.instrumentation.recordError(this.traceId, res.error);
+    } else {
+      this.instrumentation.recordResponse(this.traceId, res.status.code);
+    }
   });
   return res;
 }

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -1,90 +1,20 @@
 const rest = require('rest');
 const restInterceptor = require('../src/restInterceptor');
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
-// NOTE: CujoJS/rest sends all http status to success callback
 describe('CujoJS/rest instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function getClient() {
-    return rest.wrap(restInterceptor, {tracer: tracer.tracer(), remoteServiceName});
-  }
-
-  function successSpan(path) {
+  function clientFunction({tracer, remoteServiceName}) {
+    const wrapped = rest.wrap(restInterceptor, {tracer, remoteServiceName});
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return wrapped(url);
+      },
+      getJson(url) {
+        return wrapped(url).then(response => JSON.parse(response.entity));
       }
     });
   }
 
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return getClient()(server.url(path))
-      .then(response => expectB3Headers(tracer.popSpan(), JSON.parse(response.entity)));
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return getClient()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', () => {
-    const path = '/pathno';
-    return getClient()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '404',
-          error: '404'
-        }
-      }));
-  });
-
-  it('should report 401 in tags', () => {
-    const path = '/weather/securedTown';
-    return getClient()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '401',
-          error: '401'
-        }
-      }));
-  });
-
-  it('should report 500 in tags', () => {
-    const path = '/weather/bagCity';
-    return getClient()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '500',
-          error: '500'
-        }
-      }));
-  });
+  clientFixture.setupHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -1,190 +1,35 @@
 // defer lookup of node fetch until we know if we are node
 const wrapFetch = require('../src/wrapFetch');
 
-const {
-  expectB3Headers,
-  inBrowser,
-  setupTestServer,
-  setupTestTracer
-} = require('../../../test/testFixture');
+const {inBrowser} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
 describe('fetch instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
+  let fetch;
 
-  const server = setupTestServer();
-
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function wrappedFetch() {
-    let fetch;
+  before(() => {
     if (inBrowser()) {
       fetch = window.fetch; // eslint-disable-line
     } else { // defer loading node-fetch
       fetch = require('node-fetch'); // eslint-disable-line global-require
     }
-    return wrapFetch(fetch, {tracer: tracer.tracer(), remoteServiceName});
-  }
+  });
 
-  function successSpan(path) {
+  function clientFunction({tracer, remoteServiceName}) {
+    const wrapped = wrapFetch(fetch, {tracer, remoteServiceName});
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return wrapped(url);
+      },
+      getOptions(url) {
+        return wrapped({url});
+      },
+      getJson(url) {
+        return wrapped(url).then(response => response.json());
       }
     });
   }
 
-  it('should not interfere with errors that precede a call', (done) => {
-    // Here we are passing a function instead of the value of it. This ensures our error callback
-    // doesn't make assumptions about a span in progress: there won't be if there was a config error
-    wrappedFetch()(server.url)
-      .then((response) => {
-        done(new Error(`expected an invalid url parameter to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        const {message} = error;
-        const expected = ['must be of type string', 'must be a string']; // messages can vary in CI
-        if (message.indexOf(expected[0]) !== -1 || message.indexOf(expected[1]) !== -1) {
-          done();
-        } else {
-          done(new Error(`expected error message to match [${expected.toString()}]: ${message}`));
-        }
-      });
-  });
-
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return wrappedFetch()(server.url(path))
-      .then(response => response.json()) // json() returns a promise
-      .then(json => expectB3Headers(tracer.popSpan(), json));
-  });
-
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return wrappedFetch()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should support options request', () => {
-    const path = '/weather/wuhan';
-    return wrappedFetch()({url: server.url(path), method: 'GET'})
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', () => {
-    const path = '/pathno';
-    return wrappedFetch()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '404',
-          error: '404'
-        }
-      }));
-  });
-
-  it('should report 401 in tags', () => {
-    const path = '/weather/securedTown';
-    return wrappedFetch()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '401',
-          error: '401'
-        }
-      }));
-  });
-
-  it('should report 500 in tags', () => {
-    const path = '/weather/bagCity';
-    return wrappedFetch()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual({
-        name: 'get',
-        kind: 'CLIENT',
-        localEndpoint: {serviceName},
-        remoteEndpoint: {serviceName: remoteServiceName},
-        tags: {
-          'http.path': path,
-          'http.status_code': '500',
-          error: '500'
-        }
-      }));
-  });
-
-  it('should report when endpoint doesnt exist in tags', (done) => {
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    wrappedFetch()(badUrl)
-      .then((response) => {
-        done(new Error(`expected an invalid host to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.toString()
-          }
-        });
-        done();
-      });
-  });
-
-  it('should support nested get requests', () => {
-    const client = wrappedFetch();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client(server.url(beijing));
-    const getWuhanWeather = client(server.url(wuhan));
-
-    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
-      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
-      // This defensiveness prevents CI flakes.
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    }));
-  });
-
-  it('should support parallel get requests', () => {
-    const client = wrappedFetch();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client(server.url(beijing));
-    const getWuhanWeather = client(server.url(wuhan));
-
-    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    });
-  });
+  const testClient = clientFixture.setupHttpClientTests({clientFunction});
+  clientFixture.testOptionsArgument(testClient);
 });

--- a/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
@@ -1,194 +1,28 @@
 const got = require('got');
 const wrapGot = require('../src/wrapGot');
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
 describe('got instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function wrappedGot() {
-    return wrapGot(got, {tracer: tracer.tracer(), remoteServiceName});
-  }
-
-  function successSpan(path) {
+  function clientFunction({tracer, remoteServiceName}) {
+    const wrapped = wrapGot(got, {tracer, remoteServiceName});
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return wrapped(url, {retry: 0}).catch((error) => {
+          // Handle gotjs throwing on non 2xx status instead of passing to the normal callback.
+          if (error.response && error.response.statusCode) return error.response;
+          throw error;
+        });
+      },
+      getOptions(url) {
+        return wrapped({url});
+      },
+      getJson(url) {
+        return wrapped(url).then(response => JSON.parse(response.body));
       }
     });
   }
 
-  it('should not interfere with errors that precede a call', (done) => {
-    // Here we are passing a function instead of the value of it. This ensures our error callback
-    // doesn't make assumptions about a span in progress: there won't be if there was a config error
-    wrappedGot()(server.url)
-      .then((response) => {
-        done(new Error(`expected an invalid url parameter to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        const {message} = error;
-        const expected = ['must be of type string', 'must be a string']; // messages can vary in CI
-        if (message.indexOf(expected[0]) !== -1 || message.indexOf(expected[1]) !== -1) {
-          done();
-        } else {
-          done(new Error(`expected error message to match [${expected.toString()}]: ${message}`));
-        }
-      });
-  });
-
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return wrappedGot()(server.url(path))
-      .then(response => expectB3Headers(tracer.popSpan(), JSON.parse(response.body)));
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return wrappedGot()(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should support options request', () => {
-    const path = '/weather/wuhan';
-    return wrappedGot()({url: server.url(path), method: 'GET'})
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', (done) => {
-    const path = '/pathno';
-    wrappedGot()(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 404 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '404',
-            error: '404'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 401 in tags', (done) => {
-    const path = '/weather/securedTown';
-    wrappedGot()(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 401 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '401',
-            error: '401'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 500 in tags', (done) => {
-    const path = '/weather/bagCity';
-    wrappedGot()(server.url(path), {retry: 0})
-      .then((response) => {
-        done(new Error(`expected status 500 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '500',
-            error: '500'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report when endpoint doesnt exist in tags', (done) => {
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    wrappedGot()(badUrl, {retry: 0})
-      .then((response) => {
-        done(new Error(`expected an invalid host to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.toString()
-          }
-        });
-        done();
-      });
-  });
-
-  it('should support nested get requests', () => {
-    const client = wrappedGot();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client(server.url(beijing));
-    const getWuhanWeather = client(server.url(wuhan));
-
-    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
-      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
-      // This defensiveness prevents CI flakes.
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    }));
-  });
-
-  it('should support parallel get requests', () => {
-    const client = wrappedGot();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client(server.url(beijing));
-    const getWuhanWeather = client(server.url(wuhan));
-
-    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    });
-  });
+  const testClient = clientFixture.setupHttpClientTests({clientFunction});
+  clientFixture.testOptionsArgument(testClient);
 });

--- a/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
@@ -1,181 +1,24 @@
 const ZipkinRequest = require('../src/request').default;
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
-// NOTE: request-promise throws on non 2xx status instead of using the normal callback.
 describe('request-promise instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function getClient() {
+  function clientFunction({tracer, remoteServiceName}) {
     // NOTE: this is instantiated differently than others: you don't pass in a request function
-    return new ZipkinRequest(tracer.tracer(), remoteServiceName);
-  }
-
-  function successSpan(path) {
+    const client = new ZipkinRequest(tracer, remoteServiceName);
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return client.get(url).catch((error) => {
+          // Handle request-promise throwing on non 2xx instead of passing to the normal callback.
+          if (error.response && error.response.statusCode) return error.response;
+          throw error;
+        });
+      },
+      getJson(url) {
+        return client.get(url).then(response => JSON.parse(response));
       }
     });
   }
 
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return getClient().get(server.url(path))
-      .then(response => expectB3Headers(tracer.popSpan(), JSON.parse(response)));
-  });
-
-  // TODO: move to other http tests
-  it('should send "x-b3-flags" header when debug', () => {
-    const path = '/weather/wuhan';
-    return tracer.runInDebugTrace(() => getClient().get(server.url(path))
-      .then(response => expectB3Headers(tracer.popDebugSpan(), JSON.parse(response))));
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return getClient().get(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', (done) => {
-    const path = '/pathno';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 404 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '404',
-            error: '404'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 401 in tags', (done) => {
-    const path = '/weather/securedTown';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 401 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '401',
-            error: '401'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 500 in tags', (done) => {
-    const path = '/weather/bagCity';
-    getClient().get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 500 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '500',
-            error: '500'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report when endpoint doesnt exist in tags', function(done) { // => breaks this.timeout
-    this.timeout(1000); // Wait long than request timeout
-
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    getClient().get({url: badUrl, timeout: 300})
-      .then((response) => {
-        done(new Error(`expected an invalid host to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.cause.toString() // NOTE: this library wraps with RequestError
-          }
-        });
-        done();
-      });
-  });
-
-  it('should support nested get requests', () => {
-    const client = getClient();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client.get(server.url(beijing));
-    const getWuhanWeather = client.get(server.url(wuhan));
-
-    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
-      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
-      // This defensiveness prevents CI flakes.
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    }));
-  });
-
-  // TODO: not all http clients test this
-  it('should support parallel get requests', () => {
-    const client = getClient();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = client.get(server.url(beijing));
-    const getWuhanWeather = client.get(server.url(wuhan));
-
-    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    });
-  });
+  clientFixture.setupHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -1,122 +1,34 @@
 const request = require('request');
 const wrapRequest = require('../src/index');
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
 describe('request instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function getClient() {
-    return wrapRequest(request, {tracer: tracer.tracer(), remoteServiceName});
-  }
-
-  function successSpan(path) {
+  function clientFunction({tracer, remoteServiceName}) {
+    const wrapped = wrapRequest(request, {tracer, remoteServiceName});
+    // Intentionally doesn't use node.js promisify to work in browser and to be explicit.
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return new Promise((resolve, reject) => wrapped.get(url, (error, response) => {
+          if (error) reject(error);
+          resolve(response);
+        }));
+      },
+      getOptions(url) {
+        return new Promise((resolve, reject) => wrapped({url}, (error, response) => {
+          if (error) reject(error);
+          resolve(response);
+        }));
+      },
+      getJson(url) {
+        return new Promise((resolve, reject) => wrapped({url}, (error, response, data) => {
+          if (error) reject(error);
+          resolve(JSON.parse(data));
+        }));
       }
     });
   }
 
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    getClient().get(server.url(path)).on('body', body => expectB3Headers(tracer.popSpan(), body));
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    getClient().get(server.url(path), () => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should support options request', () => {
-    const path = '/weather/wuhan';
-    getClient()({url: server.url(path)}, () => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', () => {
-    const path = '/pathno';
-    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '404',
-        error: '404'
-      }
-    }));
-  });
-
-  it('should report 401 in tags', () => {
-    const path = '/weather/securedTown';
-    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '401',
-        error: '401'
-      }
-    }));
-  });
-
-  it('should report 500 in tags', () => {
-    const path = '/weather/bagCity';
-    getClient().get(server.url(path)).on('response', () => tracer.expectNextSpanToEqual({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '500',
-        error: '500'
-      }
-    }));
-  });
-
-  it('should report when endpoint doesnt exist in tags', (done) => {
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    getClient().get({url: badUrl, timeout: 300})
-      .on('error', (error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.toString()
-          }
-        });
-        done();
-      })
-      .on('response', response => new Error(`expected an invalid host to error. status: ${response.status}`));
-  });
-
-  it('should support nested get requests', () => {
-    const client = getClient();
-
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    client.get(server.url(beijing), () => client.get(server.url(wuhan), () => {
-      // since these are blocking requests, we should have an expected order
-      tracer.expectNextSpanToEqual(successSpan(wuhan));
-      tracer.expectNextSpanToEqual(successSpan(beijing));
-    }));
-  });
+  const testClient = clientFixture.setupHttpClientTests({clientFunction});
+  clientFixture.testOptionsArgument(testClient);
 });

--- a/packages/zipkin-instrumentation-superagent/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-superagent/test/integrationTest.js
@@ -1,167 +1,25 @@
 import request from 'superagent';
 import zipkinPlugin from '../src/superagentPlugin';
 
-const {expectB3Headers, setupTestServer, setupTestTracer} = require('../../../test/testFixture');
+const clientFixture = require('../../../test/httpClientTestFixture');
 
-// NOTE: axiosjs raises an error on non 2xx status instead of passing to the normal callback.
 describe('SuperAgent instrumentation - integration test', () => {
-  const serviceName = 'weather-app';
-  const remoteServiceName = 'weather-api';
-
-  const server = setupTestServer();
-  const tracer = setupTestTracer({localServiceName: serviceName});
-
-  function get(urlToGet) {
-    return request.get(urlToGet).use(zipkinPlugin({tracer: tracer.tracer(), remoteServiceName}));
-  }
-
-  function successSpan(path) {
+  function clientFunction({tracer, remoteServiceName}) {
+    // NOTE: SuperAgent is different as the plugin is added on each request!
+    const plugin = zipkinPlugin({tracer, remoteServiceName});
     return ({
-      name: 'get',
-      kind: 'CLIENT',
-      localEndpoint: {serviceName},
-      remoteEndpoint: {serviceName: remoteServiceName},
-      tags: {
-        'http.path': path,
-        'http.status_code': '200'
+      get(url) {
+        return request.get(url).use(plugin).catch((error) => {
+          // Handle SuperAgent throwing on non 2xx status instead of passing to the normal callback.
+          if (error.response && error.response.status) return error.response;
+          throw error;
+        });
+      },
+      getJson(url) {
+        return request.get(url).use(plugin).then(response => response.body);
       }
     });
   }
 
-  it('should add headers to requests', () => {
-    const path = '/weather/wuhan';
-    return get(server.url(path))
-      .then(response => expectB3Headers(tracer.popSpan(), response.body));
-  });
-
-  it('should support get request', () => {
-    const path = '/weather/wuhan';
-    return get(server.url(path))
-      .then(() => tracer.expectNextSpanToEqual(successSpan(path)));
-  });
-
-  it('should report 404 in tags', (done) => {
-    const path = '/pathno';
-    get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 404 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '404',
-            error: '404'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 401 in tags', (done) => {
-    const path = '/weather/securedTown';
-    get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 401 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '401',
-            error: '401'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report 500 in tags', (done) => {
-    const path = '/weather/bagCity';
-    get(server.url(path))
-      .then((response) => {
-        done(new Error(`expected status 500 response to error. status: ${response.status}`));
-      })
-      .catch(() => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            'http.status_code': '500',
-            error: '500'
-          }
-        });
-        done();
-      });
-  });
-
-  it('should report when endpoint doesnt exist in tags', (done) => {
-    const path = '/badHost';
-    const badUrl = `http://localhost:12345${path}`;
-    get(badUrl)
-      .then((response) => {
-        done(new Error(`expected an invalid host to error. status: ${response.status}`));
-      })
-      .catch((error) => {
-        tracer.expectNextSpanToEqual({
-          name: 'get',
-          kind: 'CLIENT',
-          localEndpoint: {serviceName},
-          remoteEndpoint: {serviceName: remoteServiceName},
-          tags: {
-            'http.path': path,
-            error: error.toString()
-          }
-        });
-        done();
-      });
-  });
-
-  it('should support nested get requests', () => {
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = get(server.url(beijing));
-    const getWuhanWeather = get(server.url(wuhan));
-
-    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
-      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
-      // This defensiveness prevents CI flakes.
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    }));
-  });
-
-  it('should support parallel get requests', () => {
-    const beijing = '/weather/beijing';
-    const wuhan = '/weather/wuhan';
-
-    const getBeijingWeather = get(server.url(beijing));
-    const getWuhanWeather = get(server.url(wuhan));
-
-    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
-      // since these are parallel, we have an unexpected order
-      const firstSpan = tracer.popSpan();
-      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
-      const secondPath = firstPath === wuhan ? beijing : wuhan;
-
-      tracer.expectSpan(firstSpan, successSpan(firstPath));
-      tracer.expectNextSpanToEqual(successSpan(secondPath));
-    });
-  });
+  clientFixture.setupHttpClientTests({clientFunction, requestScoped: true});
 });

--- a/test/httpClientTestFixture.js
+++ b/test/httpClientTestFixture.js
@@ -1,0 +1,286 @@
+const {expectB3Headers, setupTestServer, setupTestTracer} = require('./testFixture');
+
+// This initially holds no state as we need to await beforeEach hook to set it up.
+class TestClient {
+  constructor({
+    server,
+    tracer,
+    localServiceName,
+    remoteServiceName,
+    clientFunction,
+  }) {
+    this._server = server;
+    this._tracer = tracer;
+    this._localServiceName = localServiceName;
+    this._clientFunction = clientFunction;
+    this._remoteServiceName = remoteServiceName;
+  }
+
+  reset() {
+    this._client = this._clientFunction({
+      tracer: this._tracer.tracer(),
+      remoteServiceName: this._remoteServiceName
+    });
+  }
+
+  getJson(path) {
+    return this._client.getJson(this._server.url(path));
+  }
+
+  get({url, path}) {
+    return this._client.get(url || this._server.url(path));
+  }
+
+  getOptions(path) {
+    return this._client.getOptions(this._server.url(path));
+  }
+
+  successSpan(path) {
+    return ({
+      name: 'get',
+      kind: 'CLIENT',
+      localEndpoint: {serviceName: this._localServiceName},
+      remoteEndpoint: {serviceName: this._remoteServiceName},
+      tags: {
+        'http.path': path,
+        'http.status_code': '200'
+      }
+    });
+  }
+
+  tracer() {
+    return this._tracer;
+  }
+}
+
+// Sets up an http client test fixture which runs basic tests.
+//
+// Installation should be like this:
+//
+// ```javascript
+// const clientFixture = require('../../../test/httpClientTestFixture');
+//
+// clientFixture.setupHttpClientTests({clientFunction});
+// ```
+//
+// ## Implementing the client function
+//
+// The clientFunction takes options of {tracer, remoteServiceName} and returns an object
+// that implements the following functions:
+//
+// * get(url) - returns a promise of an http response
+// * getJson(url) - returns a promise of an object representing json
+//
+// ### Options requests (ex. client({url})
+//
+// If your client supports options requests, implement getOptions(url), and set supportsOptions true
+//
+// Ex.
+// ```javascript
+// function clientFunction({tracer, remoteServiceName}) {
+// -- snip--
+//   return ({
+//     get(url) {
+//       return wrapped(url);
+//     },
+//     getOptions(url) {
+//       return wrapped({url}); // the only object parameter used is url
+//     },
+//     getJson(url) {
+//       return wrapped(url).then(response => response.data);
+//     }
+//  });
+// }
+//
+// const testClient = clientFixture.setupHttpClientTests({clientFunction});
+// clientFixture.setupOptionsArgumentTest(testClient);
+// ```
+//
+// ## Composition approach
+//
+// Approach to compose tests is from https://github.com/mochajs/mocha/wiki/Shared-Behaviours
+function setupHttpClientTests({clientFunction, requestScoped = false}) {
+  const localServiceName = 'weather-app';
+  const remoteServiceName = 'weather-api';
+
+  const server = setupTestServer();
+  const tracer = setupTestTracer({localServiceName});
+  const testClient = new TestClient({
+    server,
+    tracer,
+    localServiceName,
+    remoteServiceName,
+    clientFunction
+  });
+
+  beforeEach(() => testClient.reset());
+
+  it('should add headers to requests', () => {
+    const path = '/weather/wuhan';
+    return testClient.getJson(path)
+      .then(json => expectB3Headers(tracer.popSpan(), json));
+  });
+
+  it('should support get request', () => {
+    const path = '/weather/wuhan';
+    return testClient.get({path})
+      .then(() => tracer.expectNextSpanToEqual(testClient.successSpan(path)));
+  });
+
+  it('should report 401 in tags', () => {
+    const path = '/weather/securedTown';
+    return testClient.get({path})
+      .then(() => tracer.expectNextSpanToEqual({
+        name: 'get',
+        kind: 'CLIENT',
+        localEndpoint: {serviceName: localServiceName},
+        remoteEndpoint: {serviceName: remoteServiceName},
+        tags: {
+          'http.path': path,
+          'http.status_code': '401',
+          error: '401'
+        }
+      }));
+  });
+
+  it('should report 404 in tags', () => {
+    const path = '/pathno';
+    return testClient.get({path})
+      .then(() => tracer.expectNextSpanToEqual({
+        name: 'get',
+        kind: 'CLIENT',
+        localEndpoint: {serviceName: localServiceName},
+        remoteEndpoint: {serviceName: remoteServiceName},
+        tags: {
+          'http.path': path,
+          'http.status_code': '404',
+          error: '404'
+        }
+      }));
+  });
+
+  it('should report 500 in tags', () => {
+    const path = '/weather/bagCity';
+    return testClient.get({path})
+      .then(() => tracer.expectNextSpanToEqual({
+        name: 'get',
+        kind: 'CLIENT',
+        localEndpoint: {serviceName: localServiceName},
+        remoteEndpoint: {serviceName: remoteServiceName},
+        tags: {
+          'http.path': path,
+          'http.status_code': '500',
+          error: '500'
+        }
+      }));
+  });
+
+  it('should report when endpoint doesnt exist in tags', (done) => {
+    const path = '/badHost';
+    testClient.get({url: `http://localhost:12345${path}`})
+      .then((response) => {
+        done(new Error(`expected an invalid host to error. status: ${response.status}`));
+      })
+      .catch((err) => {
+        // In CujoJS, response ends up in the catch block. Add debt here until we figure out if this
+        // is common or not.
+        const error = err.error ? err.error : err;
+        try {
+          tracer.expectNextSpanToEqual({
+            name: 'get',
+            kind: 'CLIENT',
+            localEndpoint: {serviceName: localServiceName},
+            remoteEndpoint: {serviceName: remoteServiceName},
+            tags: {
+              'http.path': path,
+              error: error.toString()
+            }
+          });
+          done();
+        } catch (assertionError) {
+          done(assertionError);
+        }
+      });
+  });
+
+  it('should support nested get requests', () => {
+    const beijing = '/weather/beijing';
+    const wuhan = '/weather/wuhan';
+
+    const getBeijingWeather = testClient.get({path: beijing});
+    const getWuhanWeather = testClient.get({path: wuhan});
+
+    return getBeijingWeather.then(() => getWuhanWeather.then(() => {
+      // While requests are sequential, some runtimes report out-of-order for unknown reasons.
+      // This defensiveness prevents CI flakes.
+      const firstSpan = tracer.popSpan();
+      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
+      const secondPath = firstPath === wuhan ? beijing : wuhan;
+
+      tracer.expectSpan(firstSpan, testClient.successSpan(firstPath));
+      tracer.expectNextSpanToEqual(testClient.successSpan(secondPath));
+    }));
+  });
+
+  it('should support parallel get requests', () => {
+    const beijing = '/weather/beijing';
+    const wuhan = '/weather/wuhan';
+
+    const getBeijingWeather = testClient.get({path: beijing});
+    const getWuhanWeather = testClient.get({path: wuhan});
+
+    return Promise.all([getBeijingWeather, getWuhanWeather]).then(() => {
+      // since these are parallel, we have an unexpected order
+      const firstSpan = tracer.popSpan();
+      const firstPath = firstSpan.tags['http.path'] === wuhan ? wuhan : beijing;
+      const secondPath = firstPath === wuhan ? beijing : wuhan;
+
+      tracer.expectSpan(firstSpan, testClient.successSpan(firstPath));
+      tracer.expectNextSpanToEqual(testClient.successSpan(secondPath));
+    });
+  });
+
+  if (!requestScoped) {
+    it('should not interfere with errors that precede a call', (done) => {
+      // Since we pass a function of a url instead of the value of it, we expect the client to throw
+      // an error. By checking the type of the error we can tell that we didn't mask it through an
+      // instrumentation bug (ex assumptions about a span in progress).
+      const verifyError = (error) => {
+        const {message} = error;
+        const expected = ['must be of type string', 'must be a string']; // messages can vary in CI
+        if (message.indexOf(expected[0]) !== -1 || message.indexOf(expected[1]) !== -1) {
+          done();
+        } else {
+          done(new Error(`expected error message to match [${expected.toString()}]: ${message}`));
+        }
+      };
+
+      // Sometimes middleware eagerly references the URL, guard on that.
+      let httpCall;
+      try {
+        httpCall = testClient.get({url: () => '/'});
+      } catch (error) {
+        verifyError(error);
+      }
+
+      // if we got here, the error is lazy, let's ensure it occurs!
+      if (httpCall) {
+        httpCall.then((response) => {
+          done(new Error(`expected an invalid url parameter to error. status: ${response.status}`));
+        }).catch(verifyError);
+      }
+    });
+  }
+
+  return testClient;
+}
+
+function testOptionsArgument(testClient) {
+  it('should support options argument', () => {
+    const path = '/weather/wuhan';
+    return testClient.getOptions(path)
+      .then(() => testClient.tracer().expectNextSpanToEqual(testClient.successSpan(path)));
+  });
+}
+
+module.exports = {setupHttpClientTests, testOptionsArgument};


### PR DESCRIPTION
By using a common http client test fixture, we can remove needless difference between instrumentation tests. This makes it easy to spot and correct missing tests, and also easier to identify special behaviors.