### PR TITLE
Reduces unnecessary use of beforeEach hooks in integration tests

### DIFF
--- a/packages/zipkin-instrumentation-connect/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-connect/test/integrationTest.js
@@ -20,7 +20,7 @@ describe('connect instrumentation - integration test', () => {
   let server;
   let baseURL;
 
-  afterEach(() => {
+  after(() => {
     if (server) server.close();
   });
 
@@ -58,7 +58,7 @@ describe('connect instrumentation - integration test', () => {
       tracer.tracer().letId(req._trace_id, () => tracer.tracer().recordBinary(key, value));
     }
 
-    beforeEach((done) => {
+    before((done) => {
       const app = restify.createServer({handleUncaughtExceptions: true});
       app.use(middleware({tracer: tracer.tracer()}));
       app.get('/weather/wuhan', (req, res, next) => {
@@ -143,7 +143,7 @@ describe('connect instrumentation - integration test', () => {
   });
 
   describe('express middleware', () => {
-    beforeEach((done) => {
+    before((done) => {
       const app = express();
       app.use(middleware({tracer: tracer.tracer()}));
       app.get('/weather/wuhan', (req, res) => {
@@ -227,7 +227,7 @@ describe('connect instrumentation - integration test', () => {
   describe('connect middleware', () => {
     let app; // exposed for TLS test
 
-    beforeEach((done) => {
+    before((done) => {
       app = connect();
       app.use(middleware({tracer: tracer.tracer()}));
       app.use('/weather/wuhan', (req, res) => {

--- a/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/expressMiddlewareIntegrationTest.js
@@ -17,7 +17,7 @@ describe('express instrumentation - integration test', () => {
   let server;
   let baseURL;
 
-  beforeEach((done) => {
+  before((done) => {
     const app = express();
     app.use(middleware({tracer: tracer.tracer()}));
     addTestRoutes(app, tracer.tracer());
@@ -27,7 +27,7 @@ describe('express instrumentation - integration test', () => {
     });
   });
 
-  afterEach(() => {
+  after(() => {
     if (server) server.close();
   });
 

--- a/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
+++ b/packages/zipkin-instrumentation-express/test/wrapExpressHttpProxyIntegrationTest.js
@@ -21,7 +21,7 @@ describe('express proxy instrumentation - integration test', () => {
   let frontend;
   let baseURL;
 
-  beforeEach((done) => {
+  before((done) => {
     const backendApp = express();
     addTestRoutes(backendApp); // intentionally not traced
     backend = backendApp.listen(0, () => {
@@ -46,7 +46,7 @@ describe('express proxy instrumentation - integration test', () => {
     });
   });
 
-  afterEach(() => {
+  after(() => {
     if (frontend) frontend.close();
     if (backend) backend.close();
   });

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -5,17 +5,14 @@ const {inBrowser} = require('../../../test/testFixture');
 const clientFixture = require('../../../test/httpClientTestFixture');
 
 describe('fetch instrumentation - integration test', () => {
-  let fetch;
-
-  before(() => {
+  function clientFunction({tracer, remoteServiceName}) {
+    let fetch;
     if (inBrowser()) {
       fetch = window.fetch; // eslint-disable-line
     } else { // defer loading node-fetch
       fetch = require('node-fetch'); // eslint-disable-line global-require
     }
-  });
 
-  function clientFunction({tracer, remoteServiceName}) {
     const wrapped = wrapFetch(fetch, {tracer, remoteServiceName});
     return ({
       get(url) {

--- a/packages/zipkin-instrumentation-hapi/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-hapi/test/integrationTest.js
@@ -17,7 +17,7 @@ describe('hapi instrumentation - integration test', () => {
   let server;
   let baseURL;
 
-  beforeEach((done) => {
+  before((done) => {
     server = new Hapi.Server({
       host: 'localhost',
       port: 0
@@ -92,7 +92,7 @@ describe('hapi instrumentation - integration test', () => {
       });
   });
 
-  afterEach(() => {
+  after(() => {
     if (server) server.stop();
   });
 

--- a/packages/zipkin-instrumentation-kafkajs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-kafkajs/test/integrationTest.js
@@ -26,11 +26,14 @@ describe('KafkaJS instrumentation - integration test', function() { // => doesn'
     return new Kafka({clientId: serviceName, brokers: ['localhost:9092']});
   }
 
-  beforeEach(function() { // => doesn't allow this.X
+  before(() => {
     rawKafka = newKafka();
     kafka = instrumentKafkaJs(newKafka(), {tracer: tracer.tracer(), remoteServiceName});
-    testTopic = this.test.ctx.currentTest.title.replace(/\s+/g, '-').toLowerCase();
     testMessage = {key: 'mykey', value: 'myvalue'};
+  });
+
+  beforeEach(function() { // => doesn't allow this.X
+    testTopic = this.test.ctx.currentTest.title.replace(/\s+/g, '-').toLowerCase();
   });
 
   function send(producer) {

--- a/packages/zipkin-instrumentation-restify/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-restify/test/integrationTest.js
@@ -22,7 +22,7 @@ describe('restify instrumentation - integration test', () => {
     tracer.tracer().letId(req._trace_id, () => tracer.tracer().recordBinary(key, value));
   }
 
-  beforeEach((done) => {
+  before((done) => {
     const app = restify.createServer({handleUncaughtExceptions: true});
     app.use(middleware({tracer: tracer.tracer()}));
     app.get('/weather/wuhan', (req, res, next) => {
@@ -50,7 +50,7 @@ describe('restify instrumentation - integration test', () => {
     });
   });
 
-  afterEach(() => {
+  after(() => {
     if (server) server.close();
   });
 

--- a/test/httpClientTestFixture.js
+++ b/test/httpClientTestFixture.js
@@ -12,15 +12,8 @@ class TestClient {
     this._server = server;
     this._tracer = tracer;
     this._localServiceName = localServiceName;
-    this._clientFunction = clientFunction;
     this._remoteServiceName = remoteServiceName;
-  }
-
-  reset() {
-    this._client = this._clientFunction({
-      tracer: this._tracer.tracer(),
-      remoteServiceName: this._remoteServiceName
-    });
+    this._client = clientFunction({tracer: tracer.tracer(), remoteServiceName});
   }
 
   getJson(path) {
@@ -112,8 +105,6 @@ function setupHttpClientTests({clientFunction, requestScoped = false}) {
     remoteServiceName,
     clientFunction
   });
-
-  beforeEach(() => testClient.reset());
 
   it('should add headers to requests', () => {
     const path = '/weather/wuhan';


### PR DESCRIPTION
We should only use beforeEach when state is required, but not known
until test execution (ex test name). Otherwise, it is distracting.

This removes unnecessary beforeEach and related lazy instantiation
from integration tests.