### PR TITLE
Adds http client test for redirects

### DIFF
--- a/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-axiosjs/test/integrationTest.js
@@ -6,7 +6,8 @@ const clientFixture = require('../../../test/httpClientTestFixture');
 describe('axios instrumentation - integration test', () => {
   function clientFunction({tracer, remoteServiceName}) {
     const instance = axios.create({
-      timeout: 300 // this avoids flakes in CI
+      timeout: 300, // this avoids flakes in CI
+      maxRedirects: 0
     });
 
     const wrapped = wrapAxios(instance, {tracer, remoteServiceName});
@@ -27,6 +28,5 @@ describe('axios instrumentation - integration test', () => {
     });
   }
 
-  const testClient = clientFixture.setupHttpClientTests({clientFunction});
-  clientFixture.testOptionsArgument(testClient);
+  clientFixture.setupAllHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-cujojs-rest/test/integrationTest.js
@@ -16,5 +16,5 @@ describe('CujoJS/rest instrumentation - integration test', () => {
     });
   }
 
-  clientFixture.setupHttpClientTests({clientFunction});
+  clientFixture.setupBasicHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-fetch/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-fetch/test/integrationTest.js
@@ -16,7 +16,7 @@ describe('fetch instrumentation - integration test', () => {
     const wrapped = wrapFetch(fetch, {tracer, remoteServiceName});
     return ({
       get(url) {
-        return wrapped(url);
+        return wrapped(url, {redirect: 'manual'});
       },
       getOptions(url) {
         return wrapped({url});
@@ -27,6 +27,5 @@ describe('fetch instrumentation - integration test', () => {
     });
   }
 
-  const testClient = clientFixture.setupHttpClientTests({clientFunction});
-  clientFixture.testOptionsArgument(testClient);
+  clientFixture.setupAllHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-gotjs/test/integrationTest.js
@@ -8,7 +8,7 @@ describe('got instrumentation - integration test', () => {
     const wrapped = wrapGot(got, {tracer, remoteServiceName});
     return ({
       get(url) {
-        return wrapped(url, {retry: 0}).catch((error) => {
+        return wrapped(url, {retry: 0, followRedirect: false}).catch((error) => {
           // Handle gotjs throwing on non 2xx status instead of passing to the normal callback.
           if (error.response && error.response.statusCode) return error.response;
           throw error;
@@ -23,6 +23,5 @@ describe('got instrumentation - integration test', () => {
     });
   }
 
-  const testClient = clientFixture.setupHttpClientTests({clientFunction});
-  clientFixture.testOptionsArgument(testClient);
+  clientFixture.setupAllHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request-promise/test/integrationTest.js
@@ -8,7 +8,7 @@ describe('request-promise instrumentation - integration test', () => {
     const client = new ZipkinRequest(tracer, remoteServiceName);
     return ({
       get(url) {
-        return client.get(url).catch((error) => {
+        return client.get({url, followRedirect: false}).catch((error) => {
           // Handle request-promise throwing on non 2xx instead of passing to the normal callback.
           if (error.response && error.response.statusCode) return error.response;
           throw error;
@@ -20,5 +20,6 @@ describe('request-promise instrumentation - integration test', () => {
     });
   }
 
-  clientFixture.setupHttpClientTests({clientFunction});
+  const testClient = clientFixture.setupBasicHttpClientTests({clientFunction});
+  clientFixture.setupRedirectTest(testClient);
 });

--- a/packages/zipkin-instrumentation-request/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-request/test/integrationTest.js
@@ -5,7 +5,8 @@ const clientFixture = require('../../../test/httpClientTestFixture');
 
 describe('request instrumentation - integration test', () => {
   function clientFunction({tracer, remoteServiceName}) {
-    const wrapped = wrapRequest(request, {tracer, remoteServiceName});
+    const baseRequest = request.defaults({followRedirect: false});
+    const wrapped = wrapRequest(baseRequest, {tracer, remoteServiceName});
     // Intentionally doesn't use node.js promisify to work in browser and to be explicit.
     return ({
       get(url) {
@@ -29,6 +30,5 @@ describe('request instrumentation - integration test', () => {
     });
   }
 
-  const testClient = clientFixture.setupHttpClientTests({clientFunction});
-  clientFixture.testOptionsArgument(testClient);
+  clientFixture.setupAllHttpClientTests({clientFunction});
 });

--- a/packages/zipkin-instrumentation-superagent/test/integrationTest.js
+++ b/packages/zipkin-instrumentation-superagent/test/integrationTest.js
@@ -9,7 +9,7 @@ describe('SuperAgent instrumentation - integration test', () => {
     const plugin = zipkinPlugin({tracer, remoteServiceName});
     return ({
       get(url) {
-        return request.get(url).use(plugin).catch((error) => {
+        return request.get(url).redirects(0).use(plugin).catch((error) => {
           // Handle SuperAgent throwing on non 2xx status instead of passing to the normal callback.
           if (error.response && error.response.status) return error.response;
           throw error;
@@ -21,5 +21,6 @@ describe('SuperAgent instrumentation - integration test', () => {
     });
   }
 
-  clientFixture.setupHttpClientTests({clientFunction, requestScoped: true});
+  const testClient = clientFixture.setupBasicHttpClientTests({clientFunction, requestScoped: true});
+  clientFixture.setupRedirectTest(testClient);
 });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -8,8 +8,11 @@ function middleware() {
   api.get('/weather/beijing', (req, res) => {
     res.status(200).json(req.headers);
   });
+  api.get('/weather/peking', (req, res) => {
+    res.redirect('/weather/beijing');
+  });
   api.get('/weather/securedTown', (req, res) => {
-    res.status(401).json(req.headers);
+    res.send(401);
   });
   api.get('/weather/bagCity', (req, res, next) => {
     next(new Error('service is dead'));


### PR DESCRIPTION
Of course, the abandoned CujoJS has no setting to disable redirects.