### PR TITLE
chore: adds response reader.

### DIFF
--- a/packages/zipkin-instrumentation-fetch/index.d.ts
+++ b/packages/zipkin-instrumentation-fetch/index.d.ts
@@ -1,0 +1,17 @@
+import {Tracer} from 'zipkin';
+
+// ResponseReader allows the user to customize the response based on
+// the response. In order to not to leak context, user should
+// bind this to `instrumentation`. An example use case for such
+// feature is read response header to know if the response comes
+// was cached or not.
+type ResponseReader = (traceId: string, res: any) => void
+
+declare function wrapFetch(got: any, {
+  tracer: Tracer,
+  serviceName: string,
+  remoteServiceName: string,
+  responseReader: ResponseReader
+}): any;
+
+export default wrapFetch;

--- a/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
+++ b/packages/zipkin-instrumentation-fetch/src/wrapFetch.js
@@ -2,7 +2,7 @@ const {
   Instrumentation
 } = require('zipkin');
 
-function wrapFetch(fetch, {tracer, serviceName, remoteServiceName}) {
+function wrapFetch(fetch, {tracer, serviceName, remoteServiceName, responseReader}) {
   const instrumentation = new Instrumentation.HttpClient({tracer, serviceName, remoteServiceName});
   return function zipkinfetch(input, opts = {}) {
     return new Promise((resolve, reject) => {
@@ -17,6 +17,11 @@ function wrapFetch(fetch, {tracer, serviceName, remoteServiceName}) {
             instrumentation.recordResponse(traceId, res.status);
           });
           resolve(res);
+          if (responseReader) {
+            tracer.scoped(() => {
+              responseReader.bind(instrumentation)(traceId, res);
+            });
+          }
         }).catch((err) => {
           tracer.scoped(() => {
             instrumentation.recordError(traceId, err);


### PR DESCRIPTION
This PR is still a POC of a `responseReader` which would allow users to record more information in the span based on the response. The use case that triggered this feature was that a user might want to record whether a request came from cache or not based on response header.

Ping @adriancole @ghermeto 