### PR TITLE
Added agent option to http transport

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,6 @@ lib
 es
 dist
 **/test-types/*.js
+**/tsr-declarations.js
 # this file crashes eslint
 packages/zipkin-instrumentation-request-promise/src/promise.js

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:ts": "tslint -c tslint.json -e './packages/**/node_modules/**/*.ts' './packages/**/*.ts'",
     "lint": "npm-run-all --parallel lint:*",
     "test:es": "npm run lerna-test",
-    "test:ts": "tsr packages/zipkin/test-types/*.test.ts --noAnnotate --libDeclarations && mocha --opts test/mocha-types.opts",
+    "test:ts": "tsr packages/*/test-types/*.test.ts --noAnnotate --libDeclarations && mocha --opts test/mocha-types.opts",
     "test": "npm run test:es && npm run test:ts",
     "lerna-test": "lerna run test",
     "lerna-test-browser": "lerna run test-browser",

--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,6 +1,6 @@
-import {JsonEncoder, Logger, model} from 'zipkin';
 import {Agent as HttpAgent } from 'http';
 import {Agent as HttpsAgent} from 'https';
+import {JsonEncoder, Logger, model} from 'zipkin';
 
 type Agent = HttpAgent | HttpsAgent;
 

--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,4 +1,8 @@
 import {JsonEncoder, Logger, model} from 'zipkin';
+import {Agent as HttpAgent } from 'http';
+import {Agent as HttpsAgent} from 'https';
+
+type Agent = HttpAgent | HttpsAgent;
 
 declare class HttpLogger implements Logger {
   constructor(options: {
@@ -7,6 +11,7 @@ declare class HttpLogger implements Logger {
     jsonEncoder?: JsonEncoder,
     httpTimeout?: number,
     headers?: { [name: string]: any },
+    agent?: Agent | (() => Agent),
     log?: Console
   });
   logSpan(span: model.Span): void;

--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -9,11 +9,13 @@ declare class HttpLogger implements Logger {
     endpoint: string,
     httpInterval?: number,
     jsonEncoder?: JsonEncoder,
-    httpTimeout?: number,
+    timeout?: number,
+    maxPayloadSize?: number,
     headers?: { [name: string]: any },
     agent?: Agent | (() => Agent),
     log?: Console
   });
+
   logSpan(span: model.Span): void;
 }
 export {HttpLogger};

--- a/packages/zipkin-transport-http/index.d.ts
+++ b/packages/zipkin-transport-http/index.d.ts
@@ -1,5 +1,7 @@
-import {Agent as HttpAgent } from 'http';
+import {Agent as HttpAgent} from 'http';
 import {Agent as HttpsAgent} from 'https';
+import {URL} from 'url';
+
 import {JsonEncoder, Logger, model} from 'zipkin';
 
 type Agent = HttpAgent | HttpsAgent;
@@ -12,7 +14,7 @@ declare class HttpLogger implements Logger {
     timeout?: number,
     maxPayloadSize?: number,
     headers?: { [name: string]: any },
-    agent?: Agent | (() => Agent),
+    agent?: Agent | ((url: URL) => Agent),
     log?: Console
   });
 

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -13,6 +13,7 @@ class HttpLogger extends EventEmitter {
   constructor({
     endpoint,
     headers = {},
+    agent = null,
     httpInterval = 1000,
     jsonEncoder = JSON_V1,
     timeout = 0,
@@ -23,6 +24,7 @@ class HttpLogger extends EventEmitter {
     super(); // must be before any reference to *this*
     this.log = log;
     this.endpoint = endpoint;
+    this.agent = agent;
     this.maxPayloadSize = maxPayloadSize;
     this.queue = [];
     this.queueBytes = 0;
@@ -88,6 +90,7 @@ class HttpLogger extends EventEmitter {
         body: postBody,
         headers: self.headers,
         timeout: self.timeout,
+        agent: self.agent
       }).then((response) => {
         if (response.status !== 202 && response.status !== 200) {
           const err = 'Unexpected response while sending Zipkin data, status:'

--- a/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
+++ b/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
@@ -24,14 +24,18 @@ describe('HttpLogger', () => {
   });
 
   it('should accept Http(s) Agent or function which returns Agent', () => {
-    const agents = [new HttpAgent(), new HttpsAgent(), () => new HttpAgent(), () => new HttpsAgent()];
+    const agents = [new HttpAgent(), new HttpsAgent(), () => new HttpAgent(), () => new HttpsAgent(),
+      (url: URL) => new HttpAgent(), (url: URL) => new HttpsAgent(), null, undefined];
 
     agents.forEach(agent => {
       const options = {
         endpoint: 'testEndpoint',
         agent
       };
+
       const httpLogger: HttpLogger = new HttpLogger(options);
+
+      expect(httpLogger).to.have.property('agent', agent || null);
     });
   });
 });

--- a/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
+++ b/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import {Agent as HttpAgent } from 'http';
+import {Agent as HttpsAgent} from 'https';
+import {jsonEncoder} from 'zipkin';
+
+import { HttpLogger } from 'zipkin-transport-http';
+
+describe('HttpLogger', () => {
+  it('should have correct type', () => {
+    const options = {
+      endpoint: 'testEndpoint',
+      httpInterval: 1000,
+      jsonEncoder: jsonEncoder.JSON_V1,
+      timeout: 0,
+      maxPayloadSize: 0,
+      headers: {},
+      agent: new HttpAgent(),
+      log: console
+    };
+    const httpLogger: HttpLogger = new HttpLogger(options);
+
+    expect(httpLogger.logSpan).to.be.a('function');
+  });
+
+  it('should accept Http(s) Agent or function which returns Agent', () => {
+    const agents = [new HttpAgent(), new HttpsAgent(), () => new HttpAgent(), () => new HttpsAgent()]
+
+    agents.forEach(agent => {
+      let options = {
+        endpoint: 'testEndpoint',
+        agent: agent,
+      };
+      let httpLogger: HttpLogger = new HttpLogger(options);
+    })
+  });
+});

--- a/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
+++ b/packages/zipkin-transport-http/test-types/HttpLogger.test.ts
@@ -24,14 +24,14 @@ describe('HttpLogger', () => {
   });
 
   it('should accept Http(s) Agent or function which returns Agent', () => {
-    const agents = [new HttpAgent(), new HttpsAgent(), () => new HttpAgent(), () => new HttpsAgent()]
+    const agents = [new HttpAgent(), new HttpsAgent(), () => new HttpAgent(), () => new HttpsAgent()];
 
     agents.forEach(agent => {
-      let options = {
+      const options = {
         endpoint: 'testEndpoint',
-        agent: agent,
+        agent
       };
-      let httpLogger: HttpLogger = new HttpLogger(options);
-    })
+      const httpLogger: HttpLogger = new HttpLogger(options);
+    });
   });
 });


### PR DESCRIPTION
Provide option to set a custom agent to use with node-fetch.

https://www.npmjs.com/package/node-fetch#custom-agent

This will allow users to specify any networking related options. For example, users can provide client certificates to hit mTLS endpoints, or CA certificates to use self-signed certificates.

Will use default agent if no agent option passed.