### PR TITLE
Fix typo for zipkin-instrumentation-kafkajs

### DIFF
--- a/packages/zipkin-instrumentation-kafkajs/README.md
+++ b/packages/zipkin-instrumentation-kafkajs/README.md
@@ -20,7 +20,7 @@ retry (perhaps pauses the consumer for a while) when exception is encountered ot
 ### Usage
 
 ```javascript
-const instrumentKafkaJs = require('zipkin-instrument-kafkajs');
+const instrumentKafkaJs = require('zipkin-instrumentation-kafkajs');
 
 const kafka = instrumentKafkaJs(new Kafka({
   clientId: 'my-app',


### PR DESCRIPTION
Fix required package name from the code example.