### PR TITLE
zipkin: traceid should be <2**63

### DIFF
--- a/packages/zipkin/src/tracer/randomTraceId.js
+++ b/packages/zipkin/src/tracer/randomTraceId.js
@@ -2,10 +2,13 @@
 function randomTraceId() {
   const digits = '0123456789abcdef';
   let n = '';
-  for (let i = 0; i < 16; i += 1) {
+  for (let i = 0; i < 15; i += 1) {
     const rand = Math.floor(Math.random() * 16);
     n += digits[rand];
   }
+  const rand = Math.floor(Math.random() * 8);
+  n = digits[rand] + n;
+
   return n;
 }
 


### PR DESCRIPTION
scribe defines trace_id as i64:
      https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift#L431

To my understanding, we should not interpret the 64bit hex-encoded as i64 either, I think it's safer to just generate id in the `[0; 2**63[` range.