### PR TITLE
fix: fixes undefined comparison and partial span timeout rules.

### DIFF
--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -129,7 +129,7 @@ class BatchRecorder {
     } else {
       isNew = true;
       // it can happen that timestamp is 0 hence this span will be always timed out
-      let timeoutTimestamp = (timestamp ? timestamp : now()) + this.timeout
+      const timeoutTimestamp = (timestamp || now()) + this.timeout;
       span = new PartialSpan(id, timeoutTimestamp);
     }
     updater(span);

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -105,8 +105,8 @@ class BatchRecorder {
 
   _writeSpan(id, span, isNew = false) {
     // TODO(adriancole) refactor so this responsibility isn't in writeSpan
-    if (!isNew && this.partialSpans.get(id) === 'undefined') {
-      // Span not found.  Could have been expired.
+    if (!isNew && this.partialSpans.get(id) === undefined) {
+      // Span not found. Could have been expired.
       return;
     }
 
@@ -128,7 +128,9 @@ class BatchRecorder {
       span = this.partialSpans.get(id);
     } else {
       isNew = true;
-      span = new PartialSpan(id, timestamp + this.timeout);
+      // it can happen that timestamp is 0 hence this span will be always timed out
+      let timeoutTimestamp = (timestamp ? timestamp : now()) + this.timeout
+      span = new PartialSpan(id, timeoutTimestamp);
     }
     updater(span);
     if (span.shouldFlush) {

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -109,9 +109,9 @@ class BatchRecorder {
     span.delegate.setLocalEndpoint(span.localEndpoint);
   }
 
-  _writeSpan(id, span, isNew = false) {
+  _writeSpan(id, /** @type PartialSpan */ span, isNew = false) {
     // TODO(adriancole) refactor so this responsibility isn't in writeSpan
-    if (!isNew && typeof (this.partialSpans.get(id)) === 'undefined') {
+    if (!isNew && typeof this.partialSpans.get(id) === 'undefined') {
       // Span not found. Could have been expired.
       return;
     }

--- a/packages/zipkin/src/batch-recorder.js
+++ b/packages/zipkin/src/batch-recorder.js
@@ -158,7 +158,7 @@ class BatchRecorder {
   record(rec) {
     const id = rec.traceId;
 
-    this._updateSpanMap(id, rec.timestamp, (span) => {
+    this._updateSpanMap(id, rec.timestamp, (/** @type PartialSpan */ span) => {
       switch (rec.annotation.annotationType) {
         case 'ClientAddr':
           span.delegate.setKind('SERVER');

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -13,6 +13,10 @@ const TraceId = require('../src/tracer/TraceId');
 // This test makes data bugs easier to spot by representing transformations as v2 JSON
 describe('Batch Recorder - integration test', () => {
   let spans;
+
+  /**
+   * @type {BatchRecorder}
+   */
   let recorder;
 
   beforeEach(() => {
@@ -484,6 +488,17 @@ describe('Batch Recorder - integration test', () => {
       annotations: [{timestamp: 3, value: 'finish'}]
     });
 
+    expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should not log span that is not in the reference', () => {
+    const span = {
+      delegate: {
+        timestamp: 1,
+        setLocalEndpoint: () => {}
+      }
+    };
+    recorder._writeSpan(rootId, span);
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 });

--- a/packages/zipkin/test/batch-recorder.test.js
+++ b/packages/zipkin/test/batch-recorder.test.js
@@ -491,7 +491,7 @@ describe('Batch Recorder - integration test', () => {
     expect(spans).to.be.empty; // eslint-disable-line no-unused-expressions
   });
 
-  it('should not log span that is not in the reference', () => {
+  it('should not log span that is not in partial spans list', () => {
     const span = {
       delegate: {
         timestamp: 1,


### PR DESCRIPTION
This PR fixes a comparison with `undefined` and also adds a guard for `partial spans` that have not `timestamp` attribute (because they were already reported).

Ping @adriancole 