### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ Since some of the `zipkin-js` libraries are used in both the browser and Node.js
     "baseUrl": ".",
     "paths": {
       "node-fetch": [
-        "node_modules/empty-module/index.js"
+        "node_modules/empty/index.js"
       ],
       "os": [
-        "node_modules/empty-module/index.js"
+        "node_modules/empty/index.js"
       ],
     }
   }


### PR DESCRIPTION
The `empty` module is called `empty`. If someone just copies the sample config from the readme then it will not work.