### PR TITLE
feat(http): add fallback for fetch

### DIFF
--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -109,7 +109,7 @@ class HttpLogger extends EventEmitter {
         agent: self.agent,
       };
 
-      const fetchImpl = this.fetchImplementation || defaultFetchImpl
+      const fetchImpl = this.fetchImplementation || defaultFetchImpl;
 
       fetchImpl(self.endpoint, fetchOptions).then((response) => {
         if (response.status !== 202 && response.status !== 200) {

--- a/packages/zipkin-transport-http/src/HttpLogger.js
+++ b/packages/zipkin-transport-http/src/HttpLogger.js
@@ -109,7 +109,9 @@ class HttpLogger extends EventEmitter {
         agent: self.agent,
       };
 
-      this.fetchImplementation(self.endpoint, fetchOptions).then((response) => {
+      const fetchImpl = this.fetchImplementation || defaultFetchImpl
+
+      fetchImpl(self.endpoint, fetchOptions).then((response) => {
         if (response.status !== 202 && response.status !== 200) {
           const err = 'Unexpected response while sending Zipkin data, status:'
             + `${response.status}, body: ${postBody}`;


### PR DESCRIPTION
This PR adds a fallback value to fetch when `this` loses context.

I wasn't able to add any kind of tests to verify this change, but the existing ones still pass. 

Closes https://github.com/openzipkin/zipkin-js/issues/493