### PR TITLE
Expose bindEmitter on CLSContext

### DIFF
--- a/packages/zipkin-context-cls/src/CLSContext.js
+++ b/packages/zipkin-context-cls/src/CLSContext.js
@@ -39,4 +39,8 @@ module.exports = class CLSContext {
       return callable();
     });
   }
+
+  bindEmitter(emitter) {
+    this._session.bindEmitter(emitter);
+  }
 };


### PR DESCRIPTION
I noticed that the existing test `supports async-await contexts` passes even if you disable the async await support on line 98.

I then tried to update this using an EventEmitter as I did in my other PR to more reliably reproduce the concurrent request behavior and was a bit surprised to discover that even with cls-hooked the test failed.   

It appears that when using an EventEmitter you need to explicitly register it with cls-hooked and when I did that it passed.  I then discovered that cls-continuation-context also supported a bindEmitter method and after exposing bindEmitter on context the test would pass in either implementation.  

I'm a bit sad it was necessary to explicitly register the emitter as I had hoped that when using async-hooks anything created within the context of an active namespace would automatically propagate the context, but it appears not to be the case.

So given that it is necessary to register EventEmitters with context this PR exposes that method and adds the test and I removed the existing test since it apparently does not fail when it should. 

