### PR TITLE
Changed cls-context dependency continuation-locatl-storage for cls-hooked

### DIFF
--- a/packages/zipkin-context-cls/README.md
+++ b/packages/zipkin-context-cls/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/dm/zipkin-context-cls.svg)
 
-This module implements a context API on top of [CLS/continuation-local-storage](https://github.com/othiym23/node-continuation-local-storage).
+This module implements a context API on top of [CLS/cls-hooked](https://github.com/jeff-lewis/cls-hooked).
 The primary objective of CLS is to implement a *transparent* context API, that is, you don't need to pass around a `ctx`
 variable everywhere in your application code.
 
@@ -19,7 +19,7 @@ const tracer = new Tracer({
 
 ## A note on CLS context vs. explicit context
 
-There are known issues and limitations with CLS, so some people might prefer to use `ExplicitContext` instead;
+There are known issues and limitations with CLS in nodejs, so some people might prefer to use `ExplicitContext` instead;
 the drawback then is that you have to pass around a context object manually.
 
 ## A note on CLS context and Promises

--- a/packages/zipkin-context-cls/README.md
+++ b/packages/zipkin-context-cls/README.md
@@ -26,6 +26,8 @@ the drawback then is that you have to pass around a context object manually.
 
 This package is not suitable if your code inside the context uses promises. The context is then not properly propagated. There is work underway called [async_hooks](https://nodejs.org/api/async_hooks.html), but is at the time of this writing (node v10) in Experimental state.
 
+Async hooks are ready so in this repo we will attempt to use them
+
 ## A note on the workings of CLS context
 
 The package will create a namespace called 'zipkin' by default, if it does not exist yet. In this namespace the code sets the context with the key 'zipkin'. This does not mean that the context is overwritten at every request. The namespace is tied to the call-chain. Data stored within that namespace is unique to that request and namespace. For reference see: [here](https://speakerdeck.com/fredkschott/conquering-asynchronous-context-with-cls?slide=27).

--- a/packages/zipkin-context-cls/package.json
+++ b/packages/zipkin-context-cls/package.json
@@ -13,6 +13,13 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
+    "@babel/core": "^7.9.6",
+    "cls-hooked": "^4.2.2",
     "continuation-local-storage": "^3.1.7"
+  },
+  "devDependencies": {
+    "@babel/register": "^7.9.0",
+    "babel-cli": "^6.26.0",
+    "mocha": "^7.1.2"
   }
 }

--- a/packages/zipkin-context-cls/package.json
+++ b/packages/zipkin-context-cls/package.json
@@ -13,13 +13,6 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/openzipkin/zipkin-js",
   "dependencies": {
-    "@babel/core": "^7.9.6",
-    "cls-hooked": "^4.2.2",
-    "continuation-local-storage": "^3.1.7"
-  },
-  "devDependencies": {
-    "@babel/register": "^7.9.0",
-    "babel-cli": "^6.26.0",
-    "mocha": "^7.1.2"
+    "cls-hooked": "^4.2.2"
   }
 }

--- a/packages/zipkin-context-cls/src/CLSContext.js
+++ b/packages/zipkin-context-cls/src/CLSContext.js
@@ -1,4 +1,3 @@
-//const { createNamespace, getNamespace } = require('continuation-local-storage');
 const { createNamespace, getNamespace } = require('cls-hooked');
 
 module.exports = class CLSContext {

--- a/packages/zipkin-context-cls/src/CLSContext.js
+++ b/packages/zipkin-context-cls/src/CLSContext.js
@@ -1,4 +1,5 @@
-const {createNamespace, getNamespace} = require('continuation-local-storage');
+//const { createNamespace, getNamespace } = require('continuation-local-storage');
+const { createNamespace, getNamespace } = require('cls-hooked');
 
 module.exports = class CLSContext {
   constructor(namespace = 'zipkin') {


### PR DESCRIPTION
Changed cls-context dependency continuation-locatl-storage for cls-hooked, due to the fact that cls-hooked uses new nodejs features that make cls work better and have less issues 