### PR TITLE
Fix: Module not found: node-fetch

### DIFF
--- a/packages/zipkin-transport-http/package.json
+++ b/packages/zipkin-transport-http/package.json
@@ -23,5 +23,8 @@
     "body-parser": "^1.15.2",
     "fetch-retry": "3.1.0",
     "noop-logger": "^0.1.1"
+  },
+  "browser": {
+    "node-fetch": false
   }
 }


### PR DESCRIPTION
Since the fetch implementation is figured out at runtime as described [here](https://github.com/openzipkin/zipkin-js#typescript).
I'd like to add the `"browser"` field to the `package.json` too in order to fix bundlers like webpack.
You can see more about the [`"browser"` field here](https://github.com/defunctzombie/package-browser-field-spec).

In short, this is a better fix than modifying (in my case non-existent) `tsconfig.json`

![image](https://user-images.githubusercontent.com/26925392/106020140-ba92bc80-60c3-11eb-9a4a-ebe881e070a7.png)
