### PR TITLE
Fix: Return of createNoopTracer is void

### DIFF
--- a/packages/zipkin/index.d.ts
+++ b/packages/zipkin/index.d.ts
@@ -86,7 +86,7 @@ declare namespace zipkin {
     toString(): string;
   }
 
-  const createNoopTracer: () => void;
+  const createNoopTracer: () => Tracer;
   const randomTraceId: () => string;
 
   namespace option {


### PR DESCRIPTION
The definition for `createNoobTracer()` in `index.d.ts` says that I should expect a void return.
But looking at the code that's obviously incorrect.

The hints that are created using index.d.ts
![image](https://user-images.githubusercontent.com/26925392/109286963-3bf48080-7823-11eb-8ade-9abad95ffe22.png)

The source code for `createNoopTracer` that always return a Tracer
![image](https://user-images.githubusercontent.com/26925392/109287023-53cc0480-7823-11eb-8d81-87a33b4106a1.png)

Currently a workaround for proper typings in TypeScript is:
```ts
return <unknown>createNoopTracer() as Tracer;
```