### PR TITLE
Fix bug where exceptions in other middleware are being swallowed

### DIFF
--- a/packages/zipkin-instrumentation-koa/src/koaMiddleware.js
+++ b/packages/zipkin-instrumentation-koa/src/koaMiddleware.js
@@ -46,9 +46,14 @@ module.exports = function koaMiddleware({tracer, serviceName, port = 0}) {
         });
       };
 
+      const recordError = (err) => {
+        recordResponse()
+        throw err
+      }
+
       return next()
         .then(recordResponse)
-        .catch(recordResponse);
+        .catch(recordError)
     });
   };
 };


### PR DESCRIPTION
In zipkin-instrumentation-koa, by calling `next().catch()` we catch any exceptions in the next middleware
if we are going to catch them we should throw again so that
they can be handled elsewhere.
